### PR TITLE
[공통] api client wrapper, Tanstack Query 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.74.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.5.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.74.4
+        version: 5.74.4(react@19.1.0)
       react:
         specifier: ^19.0.0
         version: 19.1.0
@@ -693,6 +696,14 @@ packages:
     resolution: {integrity: sha512-4UQeMrONbvrsXKXXp/uxmdEN5JIJ9RkH7YVzs6AMxC/KC1+Np7WZBaNIco7TEjlkthqxZbt8pU/ipD+hKjm80A==}
     peerDependencies:
       vite: ^5.2.0 || ^6
+
+  '@tanstack/query-core@5.74.4':
+    resolution: {integrity: sha512-YuG0A0+3i9b2Gfo9fkmNnkUWh5+5cFhWBN0pJAHkHilTx6A0nv8kepkk4T4GRt4e5ahbtFj2eTtkiPcVU1xO4A==}
+
+  '@tanstack/react-query@5.74.4':
+    resolution: {integrity: sha512-mAbxw60d4ffQ4qmRYfkO1xzRBPUEf/72Dgo3qqea0J66nIKuDTLEqQt0ku++SDFlMGMnB6uKDnEG1xD/TDse4Q==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -2629,6 +2640,13 @@ snapshots:
       '@tailwindcss/oxide': 4.1.4
       tailwindcss: 4.1.4
       vite: 6.3.2(jiti@2.4.2)(lightningcss@1.29.2)
+
+  '@tanstack/query-core@5.74.4': {}
+
+  '@tanstack/react-query@5.74.4(react@19.1.0)':
+    dependencies:
+      '@tanstack/query-core': 5.74.4
+      react: 19.1.0
 
   '@types/babel__core@7.20.5':
     dependencies:

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,100 @@
+const BASE_URL = import.meta.env.VITE_API_PATH;
+
+if (!BASE_URL) {
+  throw new Error('API 경로 환경변수가 설정되지 않았습니다.');
+}
+
+interface FetchOptions extends Omit<RequestInit, 'body'> {
+  headers?: Record<string, string>;
+  body?: unknown;
+}
+
+export const apiClient = {
+  get: <T = unknown>(endPoint: string, options: FetchOptions = {}) =>
+    sendRequest<T>(endPoint, { ...options, method: 'GET' }),
+  post: <T = unknown>(endPoint: string, options: FetchOptions = {}) =>
+    sendRequest<T>(endPoint, { ...options, method: 'POST' }),
+  put: <T = unknown>(endPoint: string, options: FetchOptions = {}) =>
+    sendRequest<T>(endPoint, { ...options, method: 'PUT' }),
+  delete: <T = unknown>(endPoint: string, options: FetchOptions = {}) =>
+    sendRequest<T>(endPoint, { ...options, method: 'DELETE' }),
+};
+
+async function sendRequest<T = unknown>(
+  endPoint: string,
+  options: FetchOptions = {},
+  timeout: number = 10000,
+): Promise<T> {
+  const { headers, body, method, ...restOptions } = options;
+
+  if (!method) {
+    throw new Error('HTTP method가 설정되지 않았습니다.');
+  }
+  const abortController = new AbortController();
+  const timeoutId = setTimeout(() => {
+    abortController.abort();
+  }, timeout);
+
+  const isJsonBody = body !== undefined && body !== null && !(body instanceof FormData);
+
+  try {
+    const fetchOptions: RequestInit = {
+      headers: {
+        ...(isJsonBody ? { 'Content-Type': 'application/json' } : {}),
+        ...headers,
+      },
+      method,
+      signal: abortController.signal,
+      ...restOptions,
+    };
+
+    if (body !== undefined && body !== null && !['GET', 'HEAD'].includes(method)) {
+      fetchOptions.body = typeof body === 'object' ? JSON.stringify(body) : (body as BodyInit);
+    }
+
+    const response = await fetch(`${BASE_URL}/${endPoint}`, fetchOptions);
+
+    if (!response.ok) {
+      const errorMessage = await parseResponseText(response);
+      const error = new Error(errorMessage || 'API 요청 실패');
+      Object.assign(error, {
+        status: response.status,
+        statusText: response.statusText,
+        url: response.url,
+      });
+      throw error;
+    }
+
+    return parseResponse<T>(response);
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error('요청 시간이 초과되었습니다.');
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+async function parseResponse<T = unknown>(response: Response): Promise<T> {
+  const contentType = response.headers.get('Content-Type') || '';
+  if (contentType.includes('application/json')) {
+    try {
+      return await response.json();
+    } catch {
+      return {} as T;
+    }
+  } else if (contentType.includes('text')) {
+    return (await response.text()) as unknown as T;
+  } else {
+    return null as unknown as T;
+  }
+}
+
+async function parseResponseText(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } catch {
+    return '서버로부터 응답을 받지 못했습니다.';
+  }
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -18,6 +18,8 @@ export const apiClient = {
     sendRequest<T>(endPoint, { ...options, method: 'PUT' }),
   delete: <T = unknown>(endPoint: string, options: FetchOptions = {}) =>
     sendRequest<T>(endPoint, { ...options, method: 'DELETE' }),
+  patch: <T = unknown>(endPoint: string, options: FetchOptions = {}) =>
+    sendRequest<T>(endPoint, { ...options, method: 'PATCH' }),
 };
 
 async function sendRequest<T = unknown>(

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,20 @@
 @import "tailwindcss";
 
+@theme {
+  --breakpoint-sm: 480px;
+  --breakpoint-md: 768px;
+  --breakpoint-lg: 976px;
+
+  --color-primary-300: #CE86FD;
+  --color-primary-500: #B611F5;
+
+  --color-neutral-300: #E1E1E1;
+  --color-neutral-400: #CACACA;
+  --color-neutral-500: #727272;  
+  --color-neutral-600: #4B4B4B;
+  --color-neutral-800: #000000;
+}
+
 @font-face {
   font-family: 'Pretendard';
   src: url('/fonts/Pretendard-Regular.woff2') format('woff2');

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,22 @@
 import { StrictMode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnReconnect: true,
+      retry: false,
+    },
+  },
+});
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </StrictMode>,
 );


### PR DESCRIPTION
  ##  작업 내용 🔍

- 기능 : api client wrapper 추가, Tanstack Query 추가

## 작업 주요 내용 📝
- api client wrapper 추가

``` ts
interface UserData {
  id: string;
  nickname: string;
}


export const getUser = async (): Promise<UserData> => {
  return apiClient.get<UserData>(`/user`);
};

export const createUser = async (userInfo): Promise<UserData> => {
  return apiClient.post<UserData>(`/registser`, {
    body: userInfo,
  });
};
```

get, post, put, delete 메서드를 쉽게 사용할 수 있도록 추가
(추후 토큰 관리 방식을 정한 이후 interceptor 개발할 예정)

- Tanstack Query 추가
@tanstack/react-query 최신 버전 설치
`QueryClient` 추가 ([KOIN_RECODE](https://github.com/BCSDLab/KOIN_WEB_RECODE/blob/develop/src/main.tsx#L11) 참고)

## 리뷰 중점 사항
apiClient에서 추가되어야 할 사항이 있거나, 빠진 **에러 처리** 사항이 있다면 리뷰 남겨주세요!


## ✔️ PR이 해당 조건들을 만족하는지 확인

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `pnpm lint`
