### PR TITLE
[워크플로] 리뷰어 뽑기 버그 수정

### DIFF
--- a/.github/workflows/PICK_REVIEWER.yml
+++ b/.github/workflows/PICK_REVIEWER.yml
@@ -27,12 +27,12 @@ jobs:
             const prCreatorJson = developers.reviewers.find(person => person.githubName === prCreator);
 
             const teamOrderMembers = developers.reviewers.filter((person) => person.team === "order" && person.githubName !== prCreator);
-            const randomReviewers = Array.from({ length : REVIEWER_COUNT }).map(() => getRandomReviewer(teamOrderMembers));
-            if(!prCreatorJson) setOutput(prCreator, prUrl, randomReviewers[0], randomReviewers[1]);
+            const randomReviewers = getUniqueReviewers(teamOrderMembers, REVIEWER_COUNT);
             else setOutput(prCreatorJson.name, prUrl, randomReviewers[0], randomReviewers[1]);
 
-            function getRandomReviewer(reviewers) {
-              return reviewers[Math.floor(Math.random() * reviewers.length)];
+            function getUniqueReviewers(reviewers, count) {
+              const shuffled = reviewer.sort(() => 0.5 - Math.random());
+              return shuffled.slice(0, count);
             }
 
             function setOutput(prCreator, prUrl, reviewer1, reviewer2) {


### PR DESCRIPTION
  ##  작업 내용 🔍

- 기능 : 리뷰어 뽑기 버그 수정

## 작업 주요 내용 📝
- 기존 코드는 중복된 리뷰어를 뽑을 수 있기 때문에 버그 발생 가능성 높음
- 배열을 랜덤으로 섞는 함수로 변경 `getUniqueReviewer`

## 리뷰 중점 사항
- 버그 발생 요소가 있는 지 확인해주세요~

## ✔️ PR이 해당 조건들을 만족하는지 확인

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `pnpm lint`
