### PR TITLE
[상점] 상점정보·원산지 페이지 추가

### DIFF
--- a/.github/workflows/LINT_CHECK.yml
+++ b/.github/workflows/LINT_CHECK.yml
@@ -17,7 +17,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 10
           run_install: false
 
       - name: Install Node.js

--- a/package.json
+++ b/package.json
@@ -46,5 +46,6 @@
     "typescript-eslint": "^8.26.1",
     "vite": "^6.3.1",
     "vite-plugin-svgr": "^4.3.0"
-  }
+  },
+  "packageManager": "pnpm@10.12.1"
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import DeliveryOutside from './pages/Delivery/Outside';
+import ShopDetail from './pages/shop';
 import AppLayout from '@/components/Layout';
 import Campus from '@/pages/Delivery/Campus';
 import DetailAddress from '@/pages/Delivery/Outside/DetailAddress';
@@ -17,6 +18,7 @@ export default function App() {
             <Route path="campus" element={<Campus />} />
           </Route>
           <Route path="payment" element={<Payment />} />
+          <Route path="shop-detail/:id" element={<ShopDetail />} />
         </Route>
         <Route path="result" element={<OrderFinish />} />
       </Routes>

--- a/src/api/shop/entity.ts
+++ b/src/api/shop/entity.ts
@@ -31,7 +31,7 @@ export type ShopDetailInfoResponse = {
   close_time: string | null;
   closed_days: Day[];
   phone: string;
-  introduce: string | null;
+  introduction: string | null;
   notice: string | null;
   delivery_tips: DeliveryTips[];
   owner_info: OwnerInfo;

--- a/src/api/shop/entity.ts
+++ b/src/api/shop/entity.ts
@@ -1,0 +1,39 @@
+export type ShopDetailInfoParams = {
+  orderableShopId: number;
+};
+
+type DeliveryTips = {
+  from_amount: number;
+  to_amount: number;
+  fee: number;
+};
+
+type OwnerInfo = {
+  name: string;
+  shop_name: string;
+  address: string;
+  company_registration_number: string;
+};
+
+type OriginInfo = {
+  ingredient: string;
+  origin: string;
+};
+
+export type Day = 'MONDAY' | 'TUESDAY' | 'WEDNESDAY' | 'THURSDAY' | 'FRIDAY' | 'SATURDAY' | 'SUNDAY';
+
+export type ShopDetailInfoResponse = {
+  shop_id: number;
+  orderable_shop_id: number;
+  name: string;
+  address: string;
+  open_time: string | null;
+  close_time: string | null;
+  closed_days: Day[];
+  phone: string;
+  introduce: string | null;
+  notice: string | null;
+  delivery_tips: DeliveryTips[];
+  owner_info: OwnerInfo;
+  origins: OriginInfo[];
+};

--- a/src/api/shop/index.ts
+++ b/src/api/shop/index.ts
@@ -1,0 +1,7 @@
+import { apiClient } from '..';
+import { ShopDetailInfoParams, ShopDetailInfoResponse } from './entity';
+
+export const getShopDetailInfo = async ({ orderableShopId }: ShopDetailInfoParams) => {
+  const response = await apiClient.get<ShopDetailInfoResponse>(`order/shop/${orderableShopId}/detail`);
+  return response;
+};

--- a/src/components/Layout/Header/index.tsx
+++ b/src/components/Layout/Header/index.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { ROUTE_TITLES } from './routeTitles';
 import ArrowBackIcon from '@/assets/Main/arrow-back-icon.svg';
@@ -20,8 +21,13 @@ export default function Header() {
 
   const title = ROUTE_TITLES.find((item) => item.match(pathname))?.title ?? '';
 
+  const bgClass = clsx({
+    'bg-white': pathname.startsWith('/shop-detail'),
+    'bg-[#f8f8fa]': true,
+  });
+
   return (
-    <header className="fixed top-0 right-0 left-0 z-40 flex items-center justify-center bg-[#f8f8fa] px-6 py-4">
+    <header className={`fixed top-0 right-0 left-0 z-40 flex items-center justify-center ${bgClass} px-6 py-4`}>
       <button
         type="button"
         aria-label="뒤로가기 버튼"

--- a/src/components/Layout/Header/routeTitles.ts
+++ b/src/components/Layout/Header/routeTitles.ts
@@ -1,3 +1,5 @@
+import { matchPath } from '@/util/ts/matchPath';
+
 export interface RouteTitle {
   match: (pathname: string) => boolean;
   title: string;
@@ -11,5 +13,9 @@ export const ROUTE_TITLES: RouteTitle[] = [
   {
     match: (pathname) => pathname === '/payment',
     title: '주문',
+  },
+  {
+    match: (pathname) => matchPath('/shop-detail/:id', pathname),
+    title: '가게정보·원산지',
   },
 ];

--- a/src/pages/shop/constants/day.ts
+++ b/src/pages/shop/constants/day.ts
@@ -1,0 +1,9 @@
+export const DAYS = {
+  MONDAY: '월요일',
+  TUESDAY: '화요일',
+  WEDNESDAY: '수요일',
+  THURSDAY: '목요일',
+  FRIDAY: '금요일',
+  SATURDAY: '토요일',
+  SUNDAY: '일요일',
+};

--- a/src/pages/shop/hooks/useGetShopDetail.ts
+++ b/src/pages/shop/hooks/useGetShopDetail.ts
@@ -1,0 +1,9 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { getShopDetailInfo } from '@/api/shop';
+
+export const useGetShopDetail = (orderableShopId: number) => {
+  return useSuspenseQuery({
+    queryKey: ['shopDetail', orderableShopId],
+    queryFn: () => getShopDetailInfo({ orderableShopId }),
+  });
+};

--- a/src/pages/shop/index.tsx
+++ b/src/pages/shop/index.tsx
@@ -44,7 +44,7 @@ export default function ShopDetail() {
       </div>
       <div className="bg-white px-6 py-3">
         <p className="py-3 text-[15px] leading-[1.6] font-semibold">가게 소개</p>
-        <p className="text-sm leading-[1.6] font-medium">{data.introduce}</p>
+        <p className="text-sm leading-[1.6] font-medium">{data.introduction}</p>
       </div>
       <div className="bg-white px-6 py-3">
         <p className="py-3 text-[15px] leading-[1.6] font-semibold">가게 알림</p>

--- a/src/pages/shop/index.tsx
+++ b/src/pages/shop/index.tsx
@@ -1,0 +1,99 @@
+import { useParams } from 'react-router-dom';
+import { DAYS } from './constants/day';
+import { useGetShopDetail } from './hooks/useGetShopDetail';
+
+export default function ShopDetail() {
+  const { id } = useParams();
+  if (!id) {
+    return <div className="p-6">가게 정보를 불러올 수 없습니다.</div>;
+  }
+  const { data } = useGetShopDetail(Number(id));
+
+  return (
+    <div className="flex h-full flex-col gap-1.5 peer-first:bg-white">
+      <div className="bg-white px-6 py-3">
+        <p className="py-3 text-[15px] leading-[1.6] font-semibold">{data?.name}</p>
+        <div className="flex flex-col gap-2">
+          <div className="flex gap-4 text-sm leading-[1.6] font-medium">
+            <p className="w-14 shrink-0">상호명</p>
+            <p>{data.name}</p>
+          </div>
+          <div className="flex gap-4 text-sm leading-[1.6] font-medium">
+            <p className="w-14 shrink-0">주소</p>
+            <p>{data.address}</p>
+          </div>
+          <div className="flex gap-4 text-sm leading-[1.6] font-medium">
+            <p className="w-14 shrink-0">운영시간</p>
+            <p>
+              {data.open_time?.slice(0, 5)} ~ {data.close_time?.slice(0, 5)}
+            </p>
+          </div>
+          <div className="flex gap-4 text-sm leading-[1.6] font-medium">
+            <p className="w-14 shrink-0">휴무일</p>
+            <p>
+              {data.closed_days.length === 0
+                ? '연중무휴'
+                : `매주 ${data.closed_days.map((day) => DAYS[day]).join(', ')}`}
+            </p>
+          </div>
+          <div className="flex gap-4 text-sm leading-[1.6] font-medium">
+            <p className="w-14 shrink-0">전화번호</p>
+            <p>{data.phone}</p>
+          </div>
+        </div>
+      </div>
+      <div className="bg-white px-6 py-3">
+        <p className="py-3 text-[15px] leading-[1.6] font-semibold">가게 소개</p>
+        <p className="text-sm leading-[1.6] font-medium">{data.introduce}</p>
+      </div>
+      <div className="bg-white px-6 py-3">
+        <p className="py-3 text-[15px] leading-[1.6] font-semibold">가게 알림</p>
+        <p className="text-sm leading-[1.6] font-medium">{data.notice}</p>
+      </div>
+      <div className="bg-white px-6 py-3">
+        <p className="py-3 text-[15px] leading-[1.6] font-semibold">주문금액별 총 배달팁</p>
+        <table className="w-full border border-gray-200 text-left text-sm">
+          <tbody>
+            {data.delivery_tips.map((tips) => (
+              <tr key={`${tips.from_amount}-${tips.to_amount}-${tips.fee}`} className="border-b border-gray-200">
+                <td className="border-r border-gray-200 px-4 py-2">
+                  {tips.to_amount
+                    ? `${tips.from_amount.toLocaleString()} ~ ${tips.to_amount.toLocaleString()}원 미만`
+                    : `${tips.from_amount.toLocaleString()} 이상`}
+                </td>
+                <td className="px-4 py-2">{tips.fee.toLocaleString()}원</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="bg-white px-6 py-3">
+        <p className="py-3 text-[15px] leading-[1.6] font-semibold">사업자 정보</p>
+        <div className="flex flex-col gap-2">
+          <div className="flex gap-4 text-sm leading-[1.6] font-medium">
+            <p className="w-24 shrink-0">대표자명</p>
+            <p>{data.owner_info.name}</p>
+          </div>
+          <div className="flex gap-4 text-sm leading-[1.6] font-medium">
+            <p className="w-24 shrink-0">상호명</p>
+            <p>{data.owner_info.shop_name}</p>
+          </div>
+          <div className="flex gap-4 text-sm leading-[1.6] font-medium">
+            <p className="w-24 shrink-0">사업자 주소</p>
+            <p>{data.owner_info.address}</p>
+          </div>
+          <div className="flex gap-4 text-sm leading-[1.6] font-medium">
+            <p className="w-24 shrink-0">사업자 등록 번호</p>
+            <p>{data.owner_info.company_registration_number}</p>
+          </div>
+        </div>
+      </div>
+      <div className="mb-10 bg-white px-6 py-3">
+        <p className="py-3 text-[15px] leading-[1.6] font-semibold">원산지 표기</p>
+        <p className="text-sm leading-[1.6] font-medium">
+          {data.origins.map((value) => `${value.ingredient}(${value.origin})`).join(', ')}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/util/ts/matchPath.ts
+++ b/src/util/ts/matchPath.ts
@@ -1,0 +1,10 @@
+export function matchPath(pattern: string, path: string): boolean {
+  const patternSegments = pattern.split('/').filter(Boolean);
+  const pathSegments = path.split('/').filter(Boolean);
+
+  if (patternSegments.length !== pathSegments.length) return false;
+
+  return patternSegments.every((segment, index) => {
+    return segment.startsWith(':') || segment === pathSegments[index];
+  });
+}


### PR DESCRIPTION
## 연관 이슈
- Close #36
  
##  작업 내용 🔍

- 기능 : 상점정보·원산지 페이지 추가
- issue : #36

## 작업 주요 내용 📝
- 상점 정보·원산지 페이지 UI 추가
- url 패턴 매칭을 위한 `matchPath` 유틸 함수 추가
- 가게정보 및 원산지 API 적용
- 패키지 매니저(pnpm) 버전 고정 package.json에 추가
- url `id` 값을 통해 가게정보 호출

## 스크린샷 📷
<img width="395" alt="image" src="https://github.com/user-attachments/assets/ee2d8df2-e1ae-4cde-b5e0-48463ca8c129" />
<img width="393" alt="image" src="https://github.com/user-attachments/assets/d1034fc6-f86e-4131-82f9-8de47947033c" />

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## 리뷰 중점 사항
제일 상단에 장바구니는 아직 구현하지 않았습니다. 이 부분은 모바일과 협의 후 추후에 작업하겠습니다.

## ✔️ PR이 해당 조건들을 만족하는지 확인

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `pnpm lint`
