### PR TITLE
[교외배달] 상세페이지 주소 관리 & 지도 geocode 연동

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,5 +14,7 @@
       type="text/javascript"
       src="https://oapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=%VITE_NAVER_MAPS_CLIENT_ID%"
     ></script>
+    <script type="text/javascript" src="https://oapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=%VITE_NAVER_MAPS_CLIENT_ID%&submodules=geocoder">
+    </script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "@tosspayments/tosspayments-sdk": "^2.3.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^7.5.2"
+    "react-router-dom": "^7.5.2",
+    "zustand": "^5.0.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       react-router-dom:
         specifier: ^7.5.2
         version: 7.5.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      zustand:
+        specifier: ^5.0.6
+        version: 5.0.6(@types/react@19.1.2)(react@19.1.0)
     devDependencies:
       '@eslint/js':
         specifier: ^9.22.0
@@ -2183,6 +2186,24 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zustand@5.0.6:
+    resolution: {integrity: sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -4355,3 +4376,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zustand@5.0.6(@types/react@19.1.2)(react@19.1.0):
+    optionalDependencies:
+      '@types/react': 19.1.2
+      react: 19.1.0

--- a/src/pages/Delivery/Outside/DetailAddress.tsx
+++ b/src/pages/Delivery/Outside/DetailAddress.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import useMarker from '../hooks/useMarker';
+import useNaverGeocode from '../hooks/useNaverGeocode';
 import useNaverMap from '../hooks/useNaverMap';
 import CloseIcon from '@/assets/Main/close-icon.svg';
 import ArrowDown from '@/assets/Payment/arrow-down-icon.svg';
@@ -11,9 +13,9 @@ import BottomModal, {
 } from '@/components/UI/BottomModal/BottomModal';
 import Button from '@/components/UI/Button';
 import Modal, { ModalContent } from '@/components/UI/CenterModal/Modal';
+import { useOrderStore } from '@/store/useOrderStore';
 import useBooleanState from '@/util/hooks/useBooleanState';
 
-const sample: [number, number] = [36.767, 127.284];
 const DetailRequest: string[] = [
   '문 앞에 놔주세요 (벨 눌러주세요)',
   '문 앞에 놔주세요 (노크해주세요)',
@@ -23,42 +25,79 @@ const DetailRequest: string[] = [
 ];
 
 export default function DetailAddress() {
-  const [isDeliveryBottomModalOpen, openDeliveryBottomModal, closeDeliveryBottomModal] = useBooleanState(false);
+  const { setMainAddress, setDeliveryRequest, setDetailAddress } = useOrderStore();
 
+  const location = useLocation();
+  const address = location.state?.address || '';
+
+  const navigate = useNavigate();
+
+  const [isDeliveryBottomModalOpen, openDeliveryBottomModal, closeDeliveryBottomModal] = useBooleanState(false);
   const [isModalOpen, openModal, closeModal] = useBooleanState(false);
+
+  const [selectedRequestInModal, setSelectedRequestInModal] = useState<string>('');
+  const [customInputValueInModal, setCustomInputValueInModal] = useState<string>('');
 
   const [selectedRequest, setSelectedRequest] = useState<string>('');
   const [customInputValue, setCustomInputValue] = useState<string>('');
 
-  const map = useNaverMap(...sample);
+  const [detailAddressValue, setDetailAddressValue] = useState<string>('');
+
+  const coords = useNaverGeocode(address);
+  const map = useNaverMap(...coords);
+
   useMarker(map);
 
+  const handleCLickCloseBottomModal = () => closeDeliveryBottomModal();
+
+  const getSelectRequestInModal = (detail: string) => setSelectedRequestInModal(detail);
+  const getCustomInputInModal = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setCustomInputValueInModal(e.target.value.trim());
+  };
+  const getDetailAddress = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setDetailAddressValue(e.target.value.trim());
+  };
+
   const requestLabel = () => {
-    if (!selectedRequest) {
-      return '상세 요청사항을 입력해주세요.';
-    }
-    if (selectedRequest === 'customRequest') {
-      return customInputValue || '상세 요청사항을 입력해주세요.';
-    }
+    if (!selectedRequest) return '상세 요청사항을 입력해주세요.';
+
+    if (selectedRequest === 'customRequest') return customInputValue || '상세 요청사항을 입력해주세요.';
+
     return selectedRequest;
   };
 
-  const handleSelectRequest = (detail: string) => setSelectedRequest(detail);
-  const getCustomInput = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setCustomInputValue(e.target.value.trimStart());
+  const handleSelectRequest = () => {
+    closeDeliveryBottomModal();
+    setSelectedRequest(selectedRequestInModal);
+    setCustomInputValue(customInputValueInModal);
   };
 
-  const handleSubmitRequest = () => closeDeliveryBottomModal();
+  const DeliveryRequest = () => {
+    if (selectedRequest === 'customRequest') return setDeliveryRequest(customInputValue.trim() || '요청사항 없음');
+
+    return setDeliveryRequest(selectedRequest || '요청사항 없음');
+  };
+
+  const handleClickSaveAddress = () => {
+    if (detailAddressValue.length === 0) return openModal();
+    DeliveryRequest();
+    setMainAddress(address);
+    setDetailAddress(detailAddressValue);
+  };
+
+  const backSetAddressPage = () => {
+    navigate(-1);
+  };
 
   return (
     <div className="flex flex-col items-center">
       <div className="shadow-1 w-[21.375rem] rounded-xl">
         <div id="map" className="h-40 w-full rounded-t-xl border border-neutral-300"></div>
         <div className="flex h-[3.5rem] w-full items-center justify-between rounded-b-xl bg-white px-6 text-[0.813rem] text-neutral-600">
-          충남 천안시 동남구 병천면 가전8길 102
-          <div>
+          {address}
+          <button onClick={backSetAddressPage}>
             <ArrowGo />
-          </div>
+          </button>
         </div>
       </div>
       <div className="mt-[1.813rem]">
@@ -69,6 +108,8 @@ export default function DetailAddress() {
           type="text"
           name="DetailAddress"
           placeholder="상세주소를 입력해주세요 (건물명, 동/호수 등)"
+          value={detailAddressValue}
+          onChange={getDetailAddress}
         />
       </div>
       <div className="mt-[1.813rem]">
@@ -84,7 +125,7 @@ export default function DetailAddress() {
           </div>
         </button>
       </div>
-      <Button className="mt-[18.188rem] h-[2.875rem] w-[21.375rem]" onClick={openModal}>
+      <Button className="mt-[18.188rem] h-[2.875rem] w-[21.375rem]" onClick={handleClickSaveAddress}>
         주소 선택
       </Button>
       <Modal isOpen={isModalOpen} onClose={closeModal}>
@@ -98,7 +139,7 @@ export default function DetailAddress() {
       <BottomModal isOpen={isDeliveryBottomModalOpen} onClose={closeDeliveryBottomModal}>
         <BottomModalHeader>
           <div className="text-primary-500 font-semibold">배달기사님에게</div>
-          <button onClick={closeDeliveryBottomModal}>
+          <button onClick={handleCLickCloseBottomModal}>
             <CloseIcon />
           </button>
         </BottomModalHeader>
@@ -108,15 +149,15 @@ export default function DetailAddress() {
               <label
                 key={index}
                 htmlFor={detail}
-                className={`request-label ${selectedRequest === detail && 'request-label-checked'}`}
+                className={`request-label ${selectedRequestInModal === detail && 'request-label-checked'}`}
               >
                 <div className="relative h-5 w-5">
                   <input
                     name="request"
                     id={detail}
                     type="radio"
-                    checked={selectedRequest === detail}
-                    onChange={() => handleSelectRequest(detail)}
+                    checked={selectedRequestInModal === detail}
+                    onChange={() => getSelectRequestInModal(detail)}
                     className="peer border-primary-500 absolute h-5 w-5 appearance-none rounded-full border-2 bg-white"
                   />
                   <div className="bg-primary-500 pointer-events-none absolute inset-1 rounded-full opacity-0 peer-checked:opacity-100" />
@@ -133,25 +174,25 @@ export default function DetailAddress() {
                   name="request"
                   id="customRequest"
                   type="radio"
-                  checked={selectedRequest === 'customRequest'}
-                  onChange={() => handleSelectRequest('customRequest')}
+                  checked={selectedRequestInModal === 'customRequest'}
+                  onChange={() => getSelectRequestInModal('customRequest')}
                   className="peer border-primary-500 absolute h-5 w-5 appearance-none rounded-full border-2 bg-white"
                 />
                 <div className="bg-primary-500 pointer-events-none absolute inset-1 rounded-full opacity-0 peer-checked:opacity-100" />
               </div>
               <div className="text-base">직접 입력</div>
             </label>
-            {selectedRequest === 'customRequest' && (
+            {selectedRequestInModal === 'customRequest' && (
               <input
                 type="text"
-                value={customInputValue}
+                value={customInputValueInModal}
                 placeholder="상세 요청사항을 입력해주세요."
-                onChange={getCustomInput}
+                onChange={getCustomInputInModal}
                 className="h-[3.125rem] rounded-lg border border-neutral-300 bg-white p-2 placeholder-neutral-400 placeholder:text-sm placeholder:font-normal"
               />
             )}
           </form>
-          <Button onClick={handleSubmitRequest} className="h-[2.875rem] w-full">
+          <Button onClick={handleSelectRequest} className="h-[2.875rem] w-full">
             선택하기
           </Button>
         </BottomModalContent>

--- a/src/pages/Delivery/hooks/useNaverGeocode.ts
+++ b/src/pages/Delivery/hooks/useNaverGeocode.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+function useNaverGeocode(address: string) {
+  const [coordinate, setCoordinate] = useState<[number, number]>([0, 0]);
+
+  useEffect(() => {
+    if (!address) return;
+
+    naver.maps.Service.geocode({ query: address }, (status, response) => {
+      if (status !== naver.maps.Service.Status.OK) {
+        alert('주소 변환 실패');
+        return;
+      }
+
+      const result = response.v2.addresses[0];
+      const lat = Number(result.y);
+      const lng = Number(result.x);
+
+      setCoordinate([lat, lng]);
+    });
+  }, [address]);
+
+  return coordinate;
+}
+
+export default useNaverGeocode;

--- a/src/pages/Delivery/hooks/useNaverMap.ts
+++ b/src/pages/Delivery/hooks/useNaverMap.ts
@@ -4,6 +4,8 @@ function useNaverMap(latitude: number, longitude: number) {
   const [map, setMap] = useState<naver.maps.Map | null>(null);
 
   useEffect(() => {
+    if (!latitude || !longitude) return;
+
     if (!map) {
       const newMaps = new naver.maps.Map('map', {
         center: new naver.maps.LatLng(latitude, longitude),
@@ -19,6 +21,8 @@ function useNaverMap(latitude: number, longitude: number) {
       return () => {
         newMaps.destroy();
       };
+    } else {
+      map.setCenter(new naver.maps.LatLng(latitude, longitude));
     }
 
     return () => {};

--- a/src/store/useOrderStore.ts
+++ b/src/store/useOrderStore.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+
+interface State {
+  mainAddress: string;
+  detailAddress: string;
+  deliveryRequest: string;
+}
+
+interface Action {
+  setMainAddress: (address: string) => void;
+  setDetailAddress: (detail: string) => void;
+  setDeliveryRequest: (request: string) => void;
+}
+
+export const useOrderStore = create<State & Action>((set) => ({
+  mainAddress: '',
+  detailAddress: '',
+  deliveryRequest: '',
+  setMainAddress: (address) => set({ mainAddress: address }),
+  setDetailAddress: (detail) => set({ detailAddress: detail }),
+  setDeliveryRequest: (request) => set({ deliveryRequest: request }),
+}));


### PR DESCRIPTION
## 연관 이슈
- Close #44 
  
##  작업 내용 🔍

- 기능 : 상세페이지 주소 관리 & 지도 geocode 연동
- issue : #44 

## 작업 주요 내용 📝

- 주스텐드 패키지 추가 
- 상세 페이지 주소 전역 상태 관리 스토어 추가
- 네이버 지도 geocode 스크립트 & 훅 추가 
- 해당 주소에 따른 지도 반응 추가
- 주소 선택 로직 추가 및 수정


## 스크린샷 📷

<img width="436" alt="image" src="https://github.com/user-attachments/assets/d5936e1a-b05a-4907-8aba-fa9269422b61" />
<img width="425" alt="image" src="https://github.com/user-attachments/assets/068b24e8-58ee-4804-8a4d-1b60f6e4d77d" />


## ✔️ PR이 해당 조건들을 만족하는지 확인

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `pnpm lint`
