### PR TITLE
[결제] 교내/교외 배달 여부 API 연결 및 모달 추가

### DIFF
--- a/src/api/shop/entity.ts
+++ b/src/api/shop/entity.ts
@@ -37,3 +37,8 @@ export type ShopDetailInfoResponse = {
   owner_info: OwnerInfo;
   origins: OriginInfo[];
 };
+
+export interface shopDeliveryInfoResponse {
+  campus_delivery: boolean;
+  off_campus_delivery: boolean;
+}

--- a/src/api/shop/index.ts
+++ b/src/api/shop/index.ts
@@ -1,7 +1,12 @@
 import { apiClient } from '..';
-import { ShopDetailInfoParams, ShopDetailInfoResponse } from './entity';
+import { shopDeliveryInfoResponse, ShopDetailInfoParams, ShopDetailInfoResponse } from './entity';
 
 export const getShopDetailInfo = async ({ orderableShopId }: ShopDetailInfoParams) => {
   const response = await apiClient.get<ShopDetailInfoResponse>(`order/shop/${orderableShopId}/detail`);
+  return response;
+};
+
+export const getShopDeliveryInfo = async ({ orderableShopId }: ShopDetailInfoParams) => {
+  const response = await apiClient.get<shopDeliveryInfoResponse>(`order/shop/${orderableShopId}/delivery`);
   return response;
 };

--- a/src/pages/Payment/components/AddressModal.tsx
+++ b/src/pages/Payment/components/AddressModal.tsx
@@ -1,0 +1,21 @@
+import Button from '@/components/UI/Button';
+import Modal, { ModalContent } from '@/components/UI/CenterModal/Modal';
+
+interface AddressModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  message: string;
+}
+
+export default function AddressModal({ isOpen, onClose, message }: AddressModalProps) {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalContent>
+        <div className="text-center text-[15px] leading-[160%] text-neutral-600">{message}</div>
+        <Button size="lg" fullWidth onClick={onClose}>
+          확인
+        </Button>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/pages/Payment/components/DeliveryAddressSection.tsx
+++ b/src/pages/Payment/components/DeliveryAddressSection.tsx
@@ -19,7 +19,6 @@ export default function DeliveryAddressSection({ orderableShopId }: DeliveryAddr
   const navigate = useNavigate();
   const { data: deliveryInfo } = useDeliveryInfo(orderableShopId);
 
-  console.log('Delivery Info:', deliveryInfo);
   const [isAddressModalOpen, openAddressModal, closeAddressModal] = useBooleanState(false);
   const [modalMessage, setModalMessage] = useState<string>('');
   const [deliveryAddress] = useState<{

--- a/src/pages/Payment/components/DeliveryAddressSection.tsx
+++ b/src/pages/Payment/components/DeliveryAddressSection.tsx
@@ -2,32 +2,65 @@ import { useState } from 'react';
 import clsx from 'clsx';
 import { Link, useNavigate } from 'react-router-dom';
 import { twMerge } from 'tailwind-merge';
+import useDeliveryInfo from '../hooks/useDeliveryInfo';
+import AddressModal from './AddressModal';
 import Home from '@/assets/Main/home-icon.svg';
 import University from '@/assets/Main/university-icon.svg';
 import RightArrow from '@/assets/Payment/arrow-go-icon.svg';
 import Badge from '@/components/UI/Badge';
 import Button from '@/components/UI/Button';
+import useBooleanState from '@/util/hooks/useBooleanState';
 
-export default function DeliveryAddressSection() {
+interface DeliveryAddressSectionProps {
+  orderableShopId: number;
+}
+
+export default function DeliveryAddressSection({ orderableShopId }: DeliveryAddressSectionProps) {
   const navigate = useNavigate();
+  const { data: deliveryInfo } = useDeliveryInfo(orderableShopId);
 
-  const [deliveryAddress, setDeliveryAddress] = useState<{
+  console.log('Delivery Info:', deliveryInfo);
+  const [isAddressModalOpen, openAddressModal, closeAddressModal] = useBooleanState(false);
+  const [modalMessage, setModalMessage] = useState<string>('');
+  const [deliveryAddress] = useState<{
+    // 교내외 주소 상세 페이지 완료 시 전역상태로 변경
     type: 'campus' | 'outside';
     label: string;
     detail?: string;
   } | null>(null);
+
+  const handleOutsideClick = () => {
+    if (!deliveryInfo?.off_campus_delivery) {
+      setModalMessage('이 상점은 교내만 배달 가능해요');
+      openAddressModal();
+      return;
+    }
+    navigate('/delivery/outside');
+  };
+
+  const handleCampusClick = () => {
+    if (!deliveryInfo?.campus_delivery) {
+      setModalMessage('이 상점은 교외만 배달 가능해요');
+      openAddressModal();
+      return;
+    }
+    navigate('/delivery/campus');
+  };
 
   return (
     <div>
       <div className={deliveryAddress ? 'flex items-center justify-between' : ''}>
         <p className="text-primary-500 text-lg font-semibold">배달주소</p>
         {deliveryAddress ? (
-          <Link
-            to={`/delivery/${deliveryAddress.type === 'campus' ? 'outside' : 'campus'}`}
-            className="text-xs text-neutral-500 underline"
-          >
-            {deliveryAddress.type === 'campus' ? '교외 주소를 원하시나요?' : '교내 주소를 원하시나요?'}
-          </Link>
+          (deliveryAddress.type === 'campus' && deliveryInfo?.off_campus_delivery) ||
+          (deliveryAddress.type === 'outside' && deliveryInfo?.campus_delivery) ? (
+            <Link
+              to={`/delivery/${deliveryAddress.type === 'campus' ? 'outside' : 'campus'}`}
+              className="text-xs text-neutral-500 underline"
+            >
+              {deliveryAddress.type === 'campus' ? '교외 주소를 원하시나요?' : '교내 주소를 원하시나요?'}
+            </Link>
+          ) : null
         ) : (
           <p className="text-xs text-neutral-600">배달 받을 위치를 선택해주세요.</p>
         )}
@@ -77,11 +110,8 @@ export default function DeliveryAddressSection() {
                 color="primary"
                 size="md"
                 endIcon={<University />}
-                className="text-xs"
-                // onClick={() => navigate('/delivery/campus')} 기존 동작 코드
-                onClick={() =>
-                  setDeliveryAddress({ type: 'campus', label: '105동(함지)', detail: '도착하실때 전화주세요' })
-                } // UI 테스트용 코드
+                className="text-xs max-[390px]:px-5"
+                onClick={handleCampusClick}
                 fullWidth
               >
                 <div className="leading-[160%]">
@@ -94,15 +124,8 @@ export default function DeliveryAddressSection() {
                 color="neutral"
                 size="md"
                 endIcon={<Home />}
-                className="text-xs"
-                onClick={() => navigate('/delivery/outside')}
-                // onClick={() =>
-                //   setDeliveryAddress({
-                //     type: 'outside',
-                //     label: '충남 천안시 동남구 병천면 가전8길 102 라이프원룸 404동 404호',
-                //     detail: '도착하실때 전화주세요',
-                //   })
-                // } // UI 테스트용 코드
+                className="text-xs max-[390px]:px-5"
+                onClick={handleOutsideClick}
                 fullWidth
               >
                 <div className="leading-[160%]">
@@ -114,6 +137,7 @@ export default function DeliveryAddressSection() {
           </>
         )}
       </div>
+      <AddressModal isOpen={isAddressModalOpen} onClose={closeAddressModal} message={modalMessage} />
     </div>
   );
 }

--- a/src/pages/Payment/hooks/useDeliveryInfo.ts
+++ b/src/pages/Payment/hooks/useDeliveryInfo.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+import { getShopDeliveryInfo } from '@/api/shop';
+
+export default function useDeliveryInfo(orderableShopId: number) {
+  return useQuery({
+    queryKey: ['deliveryInfo', orderableShopId],
+    queryFn: () => getShopDeliveryInfo({ orderableShopId }),
+  });
+}

--- a/src/pages/Payment/index.tsx
+++ b/src/pages/Payment/index.tsx
@@ -65,11 +65,11 @@ export default function Payment() {
           startIcon={<Bike />}
           label="배달"
         />
-        맛있는 족발 - 병천점
+        {cart.shop_name}
       </div>
 
       <div className="mt-6 flex flex-col gap-3">
-        <DeliveryAddressSection />
+        <DeliveryAddressSection orderableShopId={cart.orderable_shop_id} />
 
         <div>
           <p className="text-primary-500 text-lg font-semibold">연락처</p>

--- a/src/types/api/cart.ts
+++ b/src/types/api/cart.ts
@@ -16,8 +16,8 @@ export interface CartItem {
 }
 
 export interface CartResponse {
-  shop_name: string | null;
-  orderable_shop_id: number | null;
+  shop_name: string;
+  orderable_shop_id: number;
   is_delivery_available: boolean;
   is_takeout_available: boolean;
   shop_minimum_order_amount: number;


### PR DESCRIPTION
## 연관 이슈
- Close #53
  
##  작업 내용 🔍

- 기능 : 교내외 배달 가능 여부 조회 API 연결, 교내외 배달 불가시 모달 렌더링, 디자인 변경사항 수정
- issue : #53 

## 스크린샷 📷
<img width="376" alt="image" src="https://github.com/user-attachments/assets/4289470f-080a-4889-91d4-b9d3483bfc8e" />

## 리뷰 중점 사항
현재 DB에는 교내와 교외 배달이 모두 가능한 상점 데이터가 없어,
 UI 테스트는 mock 데이터를 활용해 진행했지만 mock 데이터를 실제 코드에는 포함시키지 않았습니다.

## ✔️ PR이 해당 조건들을 만족하는지 확인

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `pnpm lint`
