### PR TITLE
[공통] 안드로이드 브릿지 구현 및 기존 브릿지 리팩토링

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import Cart from './pages/Cart';
 import DeliveryOutside from './pages/Delivery/Outside';
 import OrderCancel from './pages/OrderFinish/OrderCancel';
 import ShopDetail from './pages/shop';
-import { requestTokensFromNative, setTokensFromNative } from './util/ts/bridge';
+import { isNative, requestTokensFromNative, setTokensFromNative } from './util/ts/bridge';
 import AppLayout from '@/components/Layout';
 import Campus from '@/pages/Delivery/Campus';
 import DetailAddress from '@/pages/Delivery/Outside/DetailAddress';
@@ -14,19 +14,13 @@ import Payment from '@/pages/Payment';
 export default function App() {
   useEffect(() => {
     const initializeTokens = async () => {
-      const { accessToken, refreshToken } = await requestTokensFromNative();
-      if (accessToken || refreshToken) {
-        setTokensFromNative({ accessToken, refreshToken });
+      if (isNative()) {
+        const tokens = await requestTokensFromNative();
+        setTokensFromNative(tokens);
       }
     };
 
-    const isIOS = !!window.webkit?.messageHandlers;
-    const isAndroid = !!window.Android;
-
-    if (typeof window !== 'undefined' && (isIOS || isAndroid)) {
-      window.setTokens = setTokensFromNative;
-      initializeTokens();
-    }
+    initializeTokens();
   }, []);
 
   return (
@@ -41,9 +35,9 @@ export default function App() {
           </Route>
           <Route path="payment" element={<Payment />} />
           <Route path="shop-detail/:id" element={<ShopDetail />} />
-          <Route path="orderCancel" element={<OrderCancel />}></Route>
+          <Route path="orderCancel" element={<OrderCancel />} />
+          <Route path="result" element={<OrderFinish />} />
         </Route>
-        <Route path="result" element={<OrderFinish />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/api/cart/index.ts
+++ b/src/api/cart/index.ts
@@ -1,10 +1,11 @@
 import { apiClient } from '..';
 import { CartResponse } from '@/api/cart/entity';
+// import { useTokenStore } from '@/stores/auth';
 
-const getToken = () => localStorage.getItem('token');
+// const token = useTokenStore.getState().token; // 배포 시 또는 브릿지 테스트 시 사용
+const token = localStorage.getItem('token'); // 개발용
 
 export const getCart = async () => {
-  const token = getToken();
   return await apiClient.get<CartResponse>('cart', {
     headers: {
       Authorization: `Bearer ${token}`,
@@ -13,7 +14,6 @@ export const getCart = async () => {
 };
 
 export const validateCart = async () => {
-  const token = getToken();
   return await apiClient.get<CartResponse>('cart/validate', {
     headers: {
       Authorization: `Bearer ${token}`,
@@ -22,7 +22,6 @@ export const validateCart = async () => {
 };
 
 export const resetCart = async () => {
-  const token = getToken();
   return await apiClient.delete('cart/reset', {
     headers: {
       Authorization: `Bearer ${token}`,
@@ -31,7 +30,6 @@ export const resetCart = async () => {
 };
 
 export const deleteCartItem = async (cartMenuItemId: number) => {
-  const token = getToken();
   return await apiClient.delete(`cart/delete/${cartMenuItemId}`, {
     headers: {
       Authorization: `Bearer ${token}`,
@@ -46,7 +44,6 @@ export const updateCartItemQuantity = async ({
   cartMenuItemId: number;
   quantity: number;
 }) => {
-  const token = getToken();
   return await apiClient.post(`cart/quantity/${cartMenuItemId}/${quantity}`, {
     headers: {
       Authorization: `Bearer ${token}`,

--- a/src/components/Layout/Header/CartResetButton.tsx
+++ b/src/components/Layout/Header/CartResetButton.tsx
@@ -1,0 +1,28 @@
+import clsx from 'clsx';
+import ResetModal from '@/pages/Cart/components/ResetModal';
+import useCart from '@/pages/Payment/hooks/useCart';
+import useBooleanState from '@/util/hooks/useBooleanState';
+
+export default function CartResetButton() {
+  const [isResetModalOpen, openResetModal, closeResetModal] = useBooleanState(false);
+  const { data: cartInfo } = useCart();
+
+  const isDisabled = cartInfo.items.length === 0;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={openResetModal}
+        disabled={isDisabled}
+        className={clsx(
+          'absolute top-1/2 right-6 -translate-y-1/2 text-sm font-semibold',
+          isDisabled ? 'text-primary-300' : 'text-primary-500',
+        )}
+      >
+        전체삭제
+      </button>
+      <ResetModal isOpen={isResetModalOpen} onClose={closeResetModal} />
+    </>
+  );
+}

--- a/src/components/Layout/Header/index.tsx
+++ b/src/components/Layout/Header/index.tsx
@@ -1,56 +1,57 @@
 import clsx from 'clsx';
 import { useLocation, useNavigate } from 'react-router-dom';
+import CartResetButton from './CartResetButton';
 import { ROUTE_TITLES } from './routeTitles';
 import ArrowBackIcon from '@/assets/Main/arrow-back-icon.svg';
-import ResetModal from '@/pages/Cart/components/ResetModal';
-import useBooleanState from '@/util/hooks/useBooleanState';
+import CloseIcon from '@/assets/Main/close-icon.svg';
+import { backButtonTapped, closeWebviewPage } from '@/util/ts/bridge';
 
 export default function Header() {
   const navigate = useNavigate();
   const { pathname } = useLocation();
 
-  const [isResetModalOpen, openResetModal, closeResetModal] = useBooleanState(false);
-
   const backToPreviousPage = () => {
-    if (pathname === '/payment') {
-      if (window.Android?.navigateBack) {
-        window.Android.navigateBack();
-      } else {
-        window.NativeBridge?.call?.('navigateBack');
-      }
-    } else {
+    if (window.history.length > 1) {
       navigate(-1);
+    } else {
+      backButtonTapped();
     }
   };
 
   const title = ROUTE_TITLES.find((item) => item.match(pathname))?.title ?? '';
 
   const bgClass = clsx({
-    'bg-white': pathname.startsWith('/shop-detail'),
+    'bg-white': pathname.startsWith('/shop-detail') || pathname.startsWith('/result'),
     'bg-[#f8f8fa]': true,
   });
 
+  const layoutClass = pathname.startsWith('/result') ? 'h-15 shadow-4' : 'py-4';
+
   return (
-    <header className={`fixed top-0 right-0 left-0 z-40 flex items-center justify-center ${bgClass} px-6 py-4`}>
-      <button
-        type="button"
-        aria-label="뒤로가기 버튼"
-        onClick={backToPreviousPage}
-        className="absolute top-1/2 left-6 -translate-y-1/2"
-      >
-        <ArrowBackIcon />
-      </button>
-      <span className="font-[Pretendard] text-lg font-medium">{title}</span>
-      {pathname === '/cart' && (
+    <header
+      className={clsx('fixed top-0 right-0 left-0 z-40 flex items-center justify-center', bgClass, 'px-6', layoutClass)}
+    >
+      {pathname.startsWith('/result') ? (
         <button
           type="button"
-          onClick={openResetModal}
-          className="text-primary-500 absolute top-1/2 right-6 -translate-y-1/2 text-sm font-semibold"
+          aria-label="닫기 버튼"
+          onClick={closeWebviewPage}
+          className="absolute top-1/2 left-6 -translate-y-1/2"
         >
-          전체삭제
+          <CloseIcon />
+        </button>
+      ) : (
+        <button
+          type="button"
+          aria-label="뒤로가기 버튼"
+          onClick={backToPreviousPage}
+          className="absolute top-1/2 left-6 -translate-y-1/2"
+        >
+          <ArrowBackIcon />
         </button>
       )}
-      <ResetModal isOpen={isResetModalOpen} onClose={closeResetModal} />
+      <span className="text-lg font-medium">{title}</span>
+      {pathname === '/cart' && <CartResetButton />}
     </header>
   );
 }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -10,7 +10,6 @@ declare global {
     };
 
     onNativeCallback?: (callbackId: string, result: unknown) => void;
-    onAndroidCallback?: (callbackId: string, result: unknown) => void;
 
     NativeBridge?: {
       call: (methodName: string, ...args: unknown[]) => Promise<unknown>;

--- a/src/pages/OrderFinish/OrderCancel.tsx
+++ b/src/pages/OrderFinish/OrderCancel.tsx
@@ -4,6 +4,7 @@ import CheckIcon from '@/assets/OrderFinish/check-icon.svg';
 import Button from '@/components/UI/Button';
 import Modal, { ModalContent } from '@/components/UI/CenterModal/Modal';
 import useBooleanState from '@/util/hooks/useBooleanState';
+import { closeWebviewPage } from '@/util/ts/bridge';
 
 const orderCancelReasons: string[] = [
   '단순 변심이에요',
@@ -32,10 +33,6 @@ export default function OrderCancel() {
     if (selectedCancelReason !== '기타') return;
     if (e.target.value === '' && customCancelReason.length === 0) return setCustomCancelReason('');
     setCustomCancelReason(e.target.value);
-  };
-
-  const handleClickMoveMainPage = () => {
-    console.log('메인 페이지 이동');
   };
 
   const handleClickSubmitReason = () => {
@@ -112,7 +109,7 @@ export default function OrderCancel() {
             >
               아니오
             </Button>
-            <Button onClick={handleClickMoveMainPage} className="w-[7.125rem] font-medium">
+            <Button onClick={closeWebviewPage} className="w-[7.125rem] font-medium">
               예
             </Button>
           </div>

--- a/src/pages/Payment/hooks/useCart.ts
+++ b/src/pages/Payment/hooks/useCart.ts
@@ -4,6 +4,6 @@ import { getCart } from '@/api/cart';
 export default function useCart() {
   return useSuspenseQuery({
     queryKey: ['cart'],
-    queryFn: () => getCart(),
+    queryFn: getCart,
   });
 }

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,26 +1,26 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import { deleteCookie } from '@/util/ts/cookie';
+import { deleteCookie, getCookie } from '@/util/ts/cookie';
 
 export type UserType = 'STUDENT' | 'GENERAL' | null;
 
-type State = {
+interface State {
   token: string;
   refreshToken: string;
   userType: UserType;
-};
+}
 
-type Actions = {
+interface Actions {
   setToken: (token: string) => void;
   setRefreshToken: (refreshToken: string) => void;
   setUserType: (userType: UserType) => void;
   clearToken: () => void;
-};
+}
 
 export const useTokenStore = create(
   persist<State & Actions>(
     (set) => ({
-      token: '',
+      token: getCookie('AUTH_TOKEN_KEY') || '',
       refreshToken: '',
       userType: null,
       setToken: (token) => set({ token }),

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -16,6 +16,8 @@
   --color-neutral-800: #000000;
 
   --shadow-1: 0px 1px 1px 0px rgba(0, 0, 0, 0.02), 0px 2px 4px 0px rgba(0, 0, 0, 0.04);
+  --shadow-2: 0px 4px 10px 0px rgba(0, 0, 0, 0.08), 0px 1px 4px 0px rgba(0, 0, 0, 0.04);
+  --shadow-4: 0px 24px 60px 0px rgba(0, 0, 0, 0.12), 0px 8px 20px 0px rgba(0, 0, 0, 0.06);
 }
 
 :root {


### PR DESCRIPTION
## 연관 이슈
- Close #59 59
  
##  작업 내용 🔍
- 액세스, 리프레시 토큰 전달
- 뒤로가기 (헤더) 
- 뒤로가기 (제스쳐)   
- 주문 완료 페이지 헤더 x 버튼
- 주문 취소 버튼 클릭 시 웹뷰 닫기

issue : #59

## 리뷰 중점 사항
안드로이드 페이지 구현이 완전하지 않아 실사용 페이지로 테스트하지는 못했지만
푸시알림을 제외한 안드로이드 브릿지 기능들은 모두 구현되었으며 
추후 안드로이드, 프론트 모두 기능 구현 완료 시 다시 한번 테스트 진행하도록 하겠습니다

## ✔️ PR이 해당 조건들을 만족하는지 확인

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `pnpm lint`
