### PR TITLE
[교외배달] 교외 배달 주소 추가 api연동

### DIFF
--- a/src/api/delivery/index.ts
+++ b/src/api/delivery/index.ts
@@ -1,5 +1,8 @@
 import { apiClient } from '..';
 import { AddressSearchRequest, AddressSearchResponse } from '@/api/delivery/entity';
+import { PostAddressObjType } from '@/stores/useOrderStore';
+
+const getToken = () => localStorage.getItem('token');
 
 export const getRoadNameAddress = async ({ keyword, currentPage, countPerPage }: AddressSearchRequest) => {
   const response = await apiClient.get<AddressSearchResponse>('address/search', {
@@ -9,5 +12,17 @@ export const getRoadNameAddress = async ({ keyword, currentPage, countPerPage }:
       countPerPage,
     },
   });
+  return response;
+};
+
+export const postUserDeliveryAddress = async (addressData: PostAddressObjType) => {
+  const token = getToken();
+  const response = await apiClient.post('delivery/address/off-campus', {
+    body: addressData,
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
   return response;
 };

--- a/src/api/delivery/index.ts
+++ b/src/api/delivery/index.ts
@@ -2,8 +2,10 @@ import { apiClient } from '..';
 import { AddressSearchRequest, AddressSearchResponse } from './entity';
 import { PostAddressObjType } from '@/stores/useOrderStore';
 import { CampusDeliveryAddressRequest, CampusDeliveryAddressResponse } from '@/types/api/deliveryCampus';
+// import { useTokenStore } from '@/stores/auth';
 
-const getToken = () => localStorage.getItem('token');
+// const token = useTokenStore.getState().token; // 배포 시 또는 브릿지 테스트 시 사용
+const token = localStorage.getItem('token'); // 개발용
 
 export const getRoadNameAddress = async ({ keyword, currentPage, countPerPage }: AddressSearchRequest) => {
   const response = await apiClient.get<AddressSearchResponse>('address/search', {
@@ -28,7 +30,6 @@ export const getCampusDeliveryAddress = async ({ filter }: CampusDeliveryAddress
 };
 
 export const postUserDeliveryAddress = async (addressData: PostAddressObjType) => {
-  const token = getToken();
   const response = await apiClient.post('delivery/address/off-campus', {
     body: addressData,
     headers: {

--- a/src/api/delivery/index.ts
+++ b/src/api/delivery/index.ts
@@ -1,7 +1,7 @@
 import { apiClient } from '..';
 import { AddressSearchRequest, AddressSearchResponse } from './entity';
-import { CampusDeliveryAddressRequest, CampusDeliveryAddressResponse } from '@/types/api/deliveryCampus';
 import { PostAddressObjType } from '@/stores/useOrderStore';
+import { CampusDeliveryAddressRequest, CampusDeliveryAddressResponse } from '@/types/api/deliveryCampus';
 
 const getToken = () => localStorage.getItem('token');
 

--- a/src/pages/Delivery/Campus/index.tsx
+++ b/src/pages/Delivery/Campus/index.tsx
@@ -1,8 +1,5 @@
 import { useState } from 'react';
 // import { useNavigate } from 'react-router-dom';
-import useMarker from '../hooks/useMarker';
-import useNaverGeocode from '../hooks/useNaverGeocode';
-import useNaverMap from '../hooks/useNaverMap';
 import AddressTypeDropdown from './AddressTypeDropdown';
 import Building from '@/assets/Delivery/building.svg';
 import NightShelter from '@/assets/Delivery/night-shelter.svg';
@@ -15,6 +12,9 @@ import BottomModal, {
   BottomModalFooter,
 } from '@/components/UI/BottomModal/BottomModal';
 import Button from '@/components/UI/Button';
+import useMarker from '@/pages/Delivery/hooks/useMarker';
+import useNaverGeocode from '@/pages/Delivery/hooks/useNaverGeocode';
+import useNaverMap from '@/pages/Delivery/hooks/useNaverMap';
 import { AddressCategory } from '@/types/api/deliveryCampus';
 import useBooleanState from '@/util/hooks/useBooleanState';
 

--- a/src/pages/Delivery/Outside/DetailAddress.tsx
+++ b/src/pages/Delivery/Outside/DetailAddress.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import useMarker from '../hooks/useMarker';
 import useNaverGeocode from '../hooks/useNaverGeocode';
 import useNaverMap from '../hooks/useNaverMap';
+import useUserDeliveryAddress from '../hooks/useUserDeliveryAddress';
 import CloseIcon from '@/assets/Main/close-icon.svg';
 import ArrowDown from '@/assets/Payment/arrow-down-icon.svg';
 import ArrowGo from '@/assets/Payment/arrow-go-icon.svg';
@@ -25,10 +26,12 @@ const DetailRequest: string[] = [
 ];
 
 export default function DetailAddress() {
-  const { setMainAddress, setDeliveryRequest, setDetailAddress } = useOrderStore();
+  const { postAddress, setDeliveryRequest, setPostAddress } = useOrderStore();
+
+  const { mutate } = useUserDeliveryAddress();
 
   const location = useLocation();
-  const address = location.state?.address || '';
+  const address = location.state?.roadAddress || '';
 
   const navigate = useNavigate();
 
@@ -78,9 +81,18 @@ export default function DetailAddress() {
 
   const handleClickSaveAddress = () => {
     if (detailAddressValue.length === 0) return openModal();
+
     DeliveryRequest();
-    setMainAddress(address);
-    setDetailAddress(detailAddressValue);
+
+    const updatedPostAddress = {
+      ...postAddress,
+      detail_address: detailAddressValue,
+      full_address: `${address} ${detailAddressValue}`,
+    };
+
+    setPostAddress(updatedPostAddress);
+    //navigate('/payment');
+    mutate(updatedPostAddress);
   };
 
   const backSetAddressPage = () => {

--- a/src/pages/Delivery/Outside/DetailAddress.tsx
+++ b/src/pages/Delivery/Outside/DetailAddress.tsx
@@ -1,9 +1,5 @@
 import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import useMarker from '../hooks/useMarker';
-import useNaverGeocode from '../hooks/useNaverGeocode';
-import useNaverMap from '../hooks/useNaverMap';
-import useUserDeliveryAddress from '../hooks/useUserDeliveryAddress';
 import CloseIcon from '@/assets/Main/close-icon.svg';
 import ArrowDown from '@/assets/Payment/arrow-down-icon.svg';
 import ArrowGo from '@/assets/Payment/arrow-go-icon.svg';
@@ -14,6 +10,10 @@ import BottomModal, {
 } from '@/components/UI/BottomModal/BottomModal';
 import Button from '@/components/UI/Button';
 import Modal, { ModalContent } from '@/components/UI/CenterModal/Modal';
+import useMarker from '@/pages/Delivery/hooks/useMarker';
+import useNaverGeocode from '@/pages/Delivery/hooks/useNaverGeocode';
+import useNaverMap from '@/pages/Delivery/hooks/useNaverMap';
+import useUserDeliveryAddress from '@/pages/Delivery/hooks/useUserDeliveryAddress';
 import { useOrderStore } from '@/stores/useOrderStore';
 import useBooleanState from '@/util/hooks/useBooleanState';
 

--- a/src/pages/Delivery/Outside/index.tsx
+++ b/src/pages/Delivery/Outside/index.tsx
@@ -2,12 +2,12 @@ import { useState } from 'react';
 import clsx from 'clsx';
 import { useNavigate } from 'react-router-dom';
 import { twMerge } from 'tailwind-merge';
-import useRoadNameAddress from '../hooks/useRoadNameAddress';
 import { Juso } from '@/api/delivery/entity';
 import InfoIcon from '@/assets/Common/info-icon.svg';
 import SearchIcon from '@/assets/Common/search-icon.svg';
 import BCSDLogoWithMagnifyIcon from '@/assets/Payment/bcsd-logo-with-magnify.svg';
 import Button from '@/components/UI/Button';
+import useRoadNameAddress from '@/pages/Delivery/hooks/useRoadNameAddress';
 import { useOrderStore } from '@/stores/useOrderStore';
 
 export default function DeliveryOutside() {

--- a/src/pages/Delivery/Outside/index.tsx
+++ b/src/pages/Delivery/Outside/index.tsx
@@ -3,16 +3,22 @@ import clsx from 'clsx';
 import { useNavigate } from 'react-router-dom';
 import { twMerge } from 'tailwind-merge';
 import useRoadNameAddress from '../hooks/useRoadNameAddress';
+import { Juso } from '@/api/delivery/entity';
 import InfoIcon from '@/assets/Common/info-icon.svg';
 import SearchIcon from '@/assets/Common/search-icon.svg';
 import BCSDLogoWithMagnifyIcon from '@/assets/Payment/bcsd-logo-with-magnify.svg';
+import { useOrderStore } from '@/stores/useOrderStore';
 
 export default function DeliveryOutside() {
+  const { setPostAddress } = useOrderStore();
+
   const navigate = useNavigate();
   const [searchKeyword, setSearchKeyword] = useState<string>('');
-  const [address, setAddress] = useState<string>('');
+  const [address, setAddress] = useState<Juso | null>(null);
 
   const { data, refetch, isSuccess, isFetched } = useRoadNameAddress(searchKeyword);
+
+  const roadAddress = address?.road_address;
 
   const handleAddressSearch = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
@@ -21,6 +27,7 @@ export default function DeliveryOutside() {
       refetch();
     }
   };
+
   return (
     <div className="mx-6 mt-4 flex min-h-[calc(100dvh-4.75rem)] flex-col items-center justify-between">
       <div className="w-full">
@@ -76,11 +83,7 @@ export default function DeliveryOutside() {
                 }),
               );
               return (
-                <button
-                  key={address.eng_address}
-                  className={className}
-                  onClick={() => setAddress(address.road_address)}
-                >
+                <button key={address.eng_address} className={className} onClick={() => setAddress(address)}>
                   <div className="text-sm leading-[1.6] font-medium text-neutral-800">
                     {address.bd_nm === '' ? address.road_address : address.bd_nm}
                   </div>
@@ -104,7 +107,21 @@ export default function DeliveryOutside() {
       </div>
       <button
         className="bg-primary-500 my-9 h-12 w-full rounded-lg text-[15px] leading-[1.6] font-semibold text-white"
-        onClick={() => navigate('/delivery/outside/detail', { state: { address } })}
+        onClick={() => {
+          if (address) {
+            setPostAddress({
+              zip_number: address.zip_no,
+              si_do: address.si_nm,
+              si_gun_gu: address.sgg_nm,
+              eup_myeon_dong: address.emd_nm,
+              road: address.rn,
+              building: address.bd_nm,
+              detail_address: '',
+              full_address: '',
+            });
+            navigate('/delivery/outside/detail', { state: { roadAddress } });
+          }
+        }}
       >
         주소 선택
       </button>

--- a/src/pages/Delivery/hooks/useUserDeliveryAddress.ts
+++ b/src/pages/Delivery/hooks/useUserDeliveryAddress.ts
@@ -1,0 +1,16 @@
+import { useMutation } from '@tanstack/react-query';
+import { postUserDeliveryAddress } from '@/api/delivery';
+import { PostAddressObjType } from '@/stores/useOrderStore';
+
+const useUserDeliveryAddress = () => {
+  return useMutation({
+    mutationFn: (addressData: PostAddressObjType) => postUserDeliveryAddress(addressData),
+    onError: (error) => {
+      console.error('배달 주소 서버 저장 실패:', error);
+    },
+    onSuccess: (data) => {
+      console.log('배달 주소 서버 저장 성공:', data);
+    },
+  });
+};
+export default useUserDeliveryAddress;

--- a/src/pages/OrderFinish/index.tsx
+++ b/src/pages/OrderFinish/index.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import useConfirmPayments from '../Payment/hooks/useConfirmPayments';
 import CloseIcon from '@/assets/Main/close-icon.svg';
 import CallIcon from '@/assets/OrderFinish/call-icon.svg';
 import Motorcycle from '@/assets/OrderFinish/motorcycle-icon.svg';
@@ -14,6 +13,7 @@ import BottomModal, {
   BottomModalFooter,
 } from '@/components/UI/BottomModal/BottomModal';
 import Button from '@/components/UI/Button';
+import useConfirmPayments from '@/pages/Payment/hooks/useConfirmPayments';
 import useBooleanState from '@/util/hooks/useBooleanState';
 
 export default function OrderFinish() {

--- a/src/stores/useOrderStore.ts
+++ b/src/stores/useOrderStore.ts
@@ -1,22 +1,38 @@
 import { create } from 'zustand';
 
 interface State {
-  mainAddress: string;
-  detailAddress: string;
+  postAddress: PostAddressObjType;
   deliveryRequest: string;
 }
 
+export interface PostAddressObjType {
+  zip_number: string;
+  si_do: string;
+  si_gun_gu: string;
+  eup_myeon_dong: string;
+  road: string;
+  building: string;
+  detail_address: string;
+  full_address: string;
+}
+
 interface Action {
-  setMainAddress: (address: string) => void;
-  setDetailAddress: (detail: string) => void;
   setDeliveryRequest: (request: string) => void;
+  setPostAddress: (addressData: PostAddressObjType) => void;
 }
 
 export const useOrderStore = create<State & Action>((set) => ({
-  mainAddress: '',
-  detailAddress: '',
+  postAddress: {
+    zip_number: '',
+    si_do: '',
+    si_gun_gu: '',
+    eup_myeon_dong: '',
+    road: '',
+    building: '',
+    detail_address: '',
+    full_address: '',
+  },
   deliveryRequest: '',
-  setMainAddress: (address) => set({ mainAddress: address }),
-  setDetailAddress: (detail) => set({ detailAddress: detail }),
   setDeliveryRequest: (request) => set({ deliveryRequest: request }),
+  setPostAddress: (addressData) => set({ postAddress: addressData }),
 }));


### PR DESCRIPTION
## 연관 이슈
- Close #61  
##  작업 내용 🔍

-기능: 교외 배달 주소 추가 api연동
- issue : #61

## 작업 주요 내용 📝

-  교외 배달 사용자 주소 서버에 추가 api 연동
- 전역 상태 스토어에 주소 객체 추가
- 주소 객체 업데이트 로직 추가


## 리뷰 중점 사항
코인에서 쓰는 api부분이 아직 익숙치 않아서 부족한 부분이 있다면 조언 해주시면 감사하겠습니다!

## ✔️ PR이 해당 조건들을 만족하는지 확인

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `pnpm lint`
