### PR TITLE
[주문 완료] 주문 상태 텍스트,타이틀 반응 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@tanstack/react-query": "^5.74.4",
     "@tosspayments/tosspayments-sdk": "^2.3.4",
+    "dayjs": "^1.11.13",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@tosspayments/tosspayments-sdk':
         specifier: ^2.3.4
         version: 2.3.4
+      dayjs:
+        specifier: ^1.11.13
+        version: 1.11.13
       react:
         specifier: ^19.0.0
         version: 19.1.0
@@ -985,6 +988,9 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  dayjs@1.11.13:
+    resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -3028,6 +3034,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  dayjs@1.11.13: {}
 
   debug@3.2.7:
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import dayjs from 'dayjs';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Cart from './pages/Cart';
 import DeliveryOutside from './pages/Delivery/Outside';
@@ -11,6 +12,9 @@ import Campus from '@/pages/Delivery/Campus';
 import DetailAddress from '@/pages/Delivery/Outside/DetailAddress';
 import OrderFinish from '@/pages/OrderFinish';
 import Payment from '@/pages/Payment';
+import 'dayjs/locale/ko';
+
+dayjs.locale('ko');
 
 export default function App() {
   useEffect(() => {

--- a/src/pages/OrderFinish/index.tsx
+++ b/src/pages/OrderFinish/index.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import dayjs from 'dayjs';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { ConfirmPaymentsResponse } from '@/api/payments/entity';
 import CloseIcon from '@/assets/Main/close-icon.svg';
@@ -20,6 +21,19 @@ import useBooleanState from '@/util/hooks/useBooleanState';
 
 export default function OrderFinish() {
   type OrderKind = 'order' | 'preparation' | 'delivery';
+
+  const stateTitle = {
+    order: '주문 확인중',
+    preparation: '준비중',
+    delivery: '배달 완료',
+  } as const;
+
+  const stateMessage = {
+    order: '사장님이 주문을 확인하고 있어요!',
+    preparation: '가게에서 열심히 음식을 조리하고있어요!',
+    delivery: '배달이 완료되었어요 감사합니다!',
+  } as const;
+
   const [searchParams] = useSearchParams();
   const orderType = searchParams.get('orderType');
   const entryPoint = searchParams.get('entryPoint');
@@ -30,13 +44,16 @@ export default function OrderFinish() {
 
   const { mutateAsync: confirmPayments, isPending } = useConfirmPayments(orderType!);
 
-  const [orderKind, setOrderKind] = useState<OrderKind>('order');
+  const [orderKind, setOrderKind] = useState<OrderKind>('delivery');
   const [paymentResponse, setPaymentResponse] = useState<ConfirmPaymentsResponse>();
 
   const [isDeliveryBottomModalOpen, , closeDeliveryBottomModal] = useBooleanState(false);
   const [isCallBottomModalOpen, openCallBottomModal, closeCallBottomModal] = useBooleanState(false);
 
   const isDelivery = orderType === 'delivery';
+
+  const approvedTime = dayjs(paymentResponse?.approved_at);
+  const deliveryFinishTime = approvedTime.add(1, 'hour').format('A h시 mm분');
 
   useEffect(() => {
     const confirmPayment = async () => {
@@ -72,17 +89,22 @@ export default function OrderFinish() {
 
   return (
     <div className="flex flex-col">
-      <div className="flex flex-row justify-between px-6 py-4">
-        <div className="text-primary-500 flex h-[3.188rem] flex-col justify-center text-xl leading-[160%] font-bold">
-          주문 확인중
-          <div className="text-xs leading-[160%] font-normal text-neutral-500">사장님이 주문을 확인하고 있어요!</div>
+      <div className="flex flex-row justify-between px-6 py-6">
+        <div className="text-primary-500 flex h-auto flex-col justify-center text-xl leading-[160%] font-bold">
+          {stateTitle[orderKind]}
+          <div className={orderKind === 'preparation' ? 'font-bold text-[#7D08A4]' : 'hidden'}>
+            {`${deliveryFinishTime} 도착 예정`}
+          </div>
+          <div className="text-xs leading-[160%] font-normal text-neutral-500">{stateMessage[orderKind]}</div>
         </div>
-        <Button
-          onClick={handleClickOrderCancel}
-          className="h-[1.938rem] w-[4.125rem] self-end rounded-3xl px-2 text-xs leading-[160%] font-semibold"
-        >
-          취소하기
-        </Button>
+        {orderKind === 'order' && (
+          <Button
+            onClick={handleClickOrderCancel}
+            className="h-[1.938rem] w-[4.125rem] self-end rounded-3xl px-2 text-xs leading-[160%] font-semibold"
+          >
+            취소하기
+          </Button>
+        )}
       </div>
       <div>
         <div className="flex flex-row justify-between px-6 pt-4 pb-1.5">


### PR DESCRIPTION
## 연관 이슈
- Close #72 
  
##  작업 내용 🔍

- 기능 : 주문 상태 텍스트,타이틀 반응 추가
- issue : #72 

## 작업 주요 내용 📝

-주문 상태 텍스트와 타이틀이 각 상태에 맞게 반응하도록 구현
-dayjs 설치 및 한국 로케일 추가
-배달 도착 예정 시간 구현

## 스크린샷 📷

<img width="338" alt="image" src="https://github.com/user-attachments/assets/04b663bb-145e-40f1-afde-06527d1f8861" />
<img width="353" alt="image" src="https://github.com/user-attachments/assets/af8d56e5-0457-4f8d-b276-7ba97da8aad5" />
<img width="348" alt="image" src="https://github.com/user-attachments/assets/16495867-0bd7-445f-9cdf-7b8a7bbcd13d" />



## ✔️ PR이 해당 조건들을 만족하는지 확인

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `pnpm lint`
