### PR TITLE
[결제] 배달가능 금액 및 최소주문 금액 계산 수정

### DIFF
--- a/src/pages/Cart/components/BottomSheet.tsx
+++ b/src/pages/Cart/components/BottomSheet.tsx
@@ -32,16 +32,16 @@ interface BottomSheetProps {
   orderType: 'DELIVERY' | 'TAKE_OUT';
   itemCount: number;
   itemTotalAmount: number;
+  totalAmount: number;
   minimumOrderAmount: number;
-  deliveryFee: number;
 }
 
 export default function BottomSheet({
   orderType,
   itemCount,
   itemTotalAmount,
+  totalAmount,
   minimumOrderAmount,
-  deliveryFee,
 }: BottomSheetProps) {
   const { mutate: validateCart, errorCode } = useValidateCart({ orderType });
   const [isValidateModalOpen, openValidateModal, closeValidateModal] = useBooleanState(false);
@@ -69,7 +69,7 @@ export default function BottomSheet({
       <div className="shadow-4 pointer-events-auto flex justify-between rounded-t-4xl border-b-[0.5px] border-neutral-300 bg-white px-6 py-3">
         <div>
           <div className="text-lg leading-[160%] font-semibold">
-            {isOrderAvailable ? (itemTotalAmount + deliveryFee).toLocaleString() : itemTotalAmount.toLocaleString()}원
+            {isOrderAvailable ? totalAmount.toLocaleString() : itemTotalAmount.toLocaleString()}원
           </div>
           <div className="text-xs leading-[160%] font-medium text-neutral-500">{statusMessage}</div>
         </div>

--- a/src/pages/Cart/index.tsx
+++ b/src/pages/Cart/index.tsx
@@ -126,8 +126,8 @@ export default function Cart() {
         orderType={orderType}
         itemCount={cartInfo.items.reduce((total, item) => total + item.quantity, 0)}
         itemTotalAmount={cartInfo.items_amount}
+        totalAmount={cartInfo.total_amount}
         minimumOrderAmount={cartInfo.shop_minimum_order_amount}
-        deliveryFee={cartInfo.delivery_fee}
       />
     </div>
   );

--- a/src/pages/Cart/test.tsx
+++ b/src/pages/Cart/test.tsx
@@ -126,8 +126,8 @@ export default function Cart() {
         orderType={orderType}
         itemCount={cartInfo.items.reduce((total, item) => total + item.quantity, 0)}
         itemTotalAmount={cartInfo.items_amount}
+        totalAmount={cartInfo.total_amount}
         minimumOrderAmount={cartInfo.shop_minimum_order_amount}
-        deliveryFee={cartInfo.delivery_fee}
       />
     </div>
   );


### PR DESCRIPTION
## 연관 이슈
- Close #90 
  
##  작업 내용 🔍

- 기능 : 배달가능 금액 및 최소주문 금액 계산 수정
- issue : #90 

## 작업 주요 내용 📝

기존 최소주문금액에 배달비도 포함하여 계산하는 로직을
음식값 자체가 최소주문금액보다 작거나 같으면 배달비를 포함하지 않음

## 스크린샷 📷

<img width="610" height="524" alt="image" src="https://github.com/user-attachments/assets/d30e6358-e091-4329-957d-51f6bc39c546" />


## ✔️ PR이 해당 조건들을 만족하는지 확인

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `pnpm lint`
