### PR TITLE
[메뉴담기&장바구니] 비로그인 상태에서 메뉴 담기 시 정보 저장 및 로그인 후 장바구니에 유지

### DIFF
--- a/src/pages/Cart/index.tsx
+++ b/src/pages/Cart/index.tsx
@@ -32,14 +32,11 @@ export default function Cart() {
   }
 
   useEffect(() => {
-    const raw = localStorage.getItem('menuOptions');
-    if (raw) {
-      try {
-        const request: AddCartRequest = JSON.parse(raw);
-        addToCart(request);
-      } finally {
-        localStorage.removeItem('menuOptions');
-      }
+    const storedMenuOptions = localStorage.getItem('menuOptions');
+    if (storedMenuOptions) {
+      const request: AddCartRequest = JSON.parse(storedMenuOptions);
+      addToCart(request);
+      localStorage.removeItem('menuOptions');
     }
   }, []);
 

--- a/src/pages/Cart/index.tsx
+++ b/src/pages/Cart/index.tsx
@@ -1,9 +1,12 @@
+import { useEffect } from 'react';
 import clsx from 'clsx';
 import { useNavigate } from 'react-router-dom';
 import useCart from '../Payment/hooks/useCart';
+import useAddCart from '../Shop/hooks/useAddCart';
 import BottomSheet from './components/BottomSheet';
 import CartItem from './components/CartItem';
 import PaymentAmount from './components/PaymentAmount';
+import { AddCartRequest } from '@/api/cart/entity';
 import EmptyCart from '@/assets/Cart/cart-icon.svg';
 import Plus from '@/assets/Cart/plus-icon.svg';
 import Info from '@/assets/Cart/primary-info-icon.svg';
@@ -18,6 +21,7 @@ export default function Cart() {
   const { orderType, setOrderType } = useOrderStore();
 
   const { data: cartInfo } = useCart(orderType);
+  const { mutateAsync: addToCart } = useAddCart();
 
   let infoMessage = '';
 
@@ -26,6 +30,18 @@ export default function Cart() {
   } else if (cartInfo.is_delivery_available && !cartInfo.is_takeout_available) {
     infoMessage = '이 가게는 배달주문만 가능해요';
   }
+
+  useEffect(() => {
+    const raw = localStorage.getItem('menuOptions');
+    if (raw) {
+      try {
+        const request: AddCartRequest = JSON.parse(raw);
+        addToCart(request);
+      } finally {
+        localStorage.removeItem('menuOptions');
+      }
+    }
+  }, []);
 
   if (cartInfo.items.length === 0) {
     return (

--- a/src/pages/Shop/MenuDetail/index.tsx
+++ b/src/pages/Shop/MenuDetail/index.tsx
@@ -128,7 +128,11 @@ export default function MenuDetail() {
       />
       <ResetModal isOpen={isResetModalOpen} onClose={closeResetModal} />
       <NoticeModal isOpen={isNoticeModalOpen} onClose={closeNoticeModal} message={noticeMessage} />
-      <LoginRequiredModal isOpen={isLoginRequiredModalOpen} onClose={closeLoginRequiredModal} />
+      <LoginRequiredModal
+        isOpen={isLoginRequiredModalOpen}
+        onClose={closeLoginRequiredModal}
+        menuOptions={'menuInfo' in addToCartRequest ? addToCartRequest : undefined}
+      />
     </div>
   );
 }

--- a/src/pages/Shop/components/LoginRequiredModal.tsx
+++ b/src/pages/Shop/components/LoginRequiredModal.tsx
@@ -1,14 +1,19 @@
+import { AddCartRequest } from '@/api/cart/entity';
 import Button from '@/components/UI/Button';
 import Modal, { ModalContent } from '@/components/UI/CenterModal/Modal';
 
 interface LoginRequiredModalProps {
   isOpen: boolean;
   onClose: () => void;
+  menuOptions?: AddCartRequest;
 }
 
-export default function LoginRequiredModal({ isOpen, onClose }: LoginRequiredModalProps) {
+export default function LoginRequiredModal({ isOpen, onClose, menuOptions }: LoginRequiredModalProps) {
   const redirectToLogin = () => {
-    // 로그인 페이지로..
+    if (menuOptions) {
+      localStorage.setItem('menuOptions', JSON.stringify(menuOptions));
+    }
+    // 브릿지 추가 예정
     onClose();
   };
 

--- a/src/pages/Shop/hooks/useAddCart.ts
+++ b/src/pages/Shop/hooks/useAddCart.ts
@@ -8,7 +8,7 @@ export default function useAddCart() {
   return useMutation({
     mutationFn: (menuInfo: AddCartRequest) => addCart(menuInfo),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['cartAdd'] });
+      queryClient.invalidateQueries({ queryKey: ['cart'] });
     },
   });
 }


### PR DESCRIPTION
## 연관 이슈
- Close #96 

## 작업 주요 내용 📝
비로그인 사용자가 메뉴 담기 시도 및 로그인 페이지 이동 시 담으려고 했던 메뉴 옵션들을 로컬스토리지에 저장 후 로그인 후 장바구니 페이지로 되돌아 왔을때 저장해두었던 옵션을 바로 담아서 보여주는 로직이 구현되었습니다.

## 스크린샷 📷

https://github.com/user-attachments/assets/63ad3c96-dfbd-4b46-be07-28e0e45b67a4

## 리뷰 중점 사항


## ✔️ PR이 해당 조건들을 만족하는지 확인

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `pnpm lint`
