### PR TITLE
[결제] 3차 QA 이슈 수정

### DIFF
--- a/src/components/Layout/Header/index.tsx
+++ b/src/components/Layout/Header/index.tsx
@@ -4,14 +4,22 @@ import CartResetButton from './CartResetButton';
 import { ROUTE_TITLES } from './routeTitles';
 import ArrowBackIcon from '@/assets/Main/arrow-back-icon.svg';
 import CloseIcon from '@/assets/Main/close-icon.svg';
-import { backButtonTapped } from '@/util/ts/bridge';
+import { backButtonTapped, isAndroid, isIOS } from '@/util/ts/bridge';
 
 export default function Header() {
   const navigate = useNavigate();
   const { pathname } = useLocation();
 
   const backToPreviousPage = () => {
-    if (window.history.length > 1) {
+    if (pathname.startsWith('/payment')) {
+      if (isAndroid()) {
+        backButtonTapped();
+      } else if (isIOS()) {
+        navigate('/cart', { replace: true });
+      } else {
+        navigate('/cart', { replace: true });
+      }
+    } else if (window.history.length > 1) {
       navigate(-1);
     } else {
       backButtonTapped();

--- a/src/components/Layout/Header/index.tsx
+++ b/src/components/Layout/Header/index.tsx
@@ -4,7 +4,7 @@ import CartResetButton from './CartResetButton';
 import { ROUTE_TITLES } from './routeTitles';
 import ArrowBackIcon from '@/assets/Main/arrow-back-icon.svg';
 import CloseIcon from '@/assets/Main/close-icon.svg';
-import { backButtonTapped, isAndroid, isIOS } from '@/util/ts/bridge';
+import { backButtonTapped, isAndroid } from '@/util/ts/bridge';
 
 export default function Header() {
   const navigate = useNavigate();
@@ -14,8 +14,6 @@ export default function Header() {
     if (pathname.startsWith('/payment')) {
       if (isAndroid()) {
         backButtonTapped();
-      } else if (isIOS()) {
-        navigate('/cart', { replace: true });
       } else {
         navigate('/cart', { replace: true });
       }

--- a/src/pages/Payment/components/ContactModal.tsx
+++ b/src/pages/Payment/components/ContactModal.tsx
@@ -58,7 +58,7 @@ export default function ContactModal({ isOpen, onClose, currentContact, onSubmit
     setCodeErrorMessage('');
     setPhoneErrorMessage('');
     setTimer(0);
-    isFalseEditing();
+    isTrueEditing();
   };
 
   const closeModal = () => {

--- a/src/pages/Payment/index.tsx
+++ b/src/pages/Payment/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { TossPaymentsWidgets } from '@tosspayments/tosspayments-sdk';
 import clsx from 'clsx';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import Agreement from './components/Agreement';
 import ContactModal from './components/ContactModal';
 import DeliveryAddressSection from './components/DeliveryAddressSection';
@@ -26,6 +26,7 @@ import { useToast } from '@/util/hooks/useToast';
 import formatPhoneNumber from '@/util/ts/formatPhoneNumber';
 
 export default function Payment() {
+  const navigate = useNavigate();
   const { showToast } = useToast();
   const [searchParams] = useSearchParams();
   const [isContactModalOpen, openContactModal, closeContactModal] = useBooleanState(false);
@@ -105,6 +106,18 @@ export default function Payment() {
     } catch (error) {
       console.error(error);
     }
+  };
+
+  const handleCloseFailModal = () => {
+    closePaymentFailModal();
+    searchParams.delete('message');
+    navigate(
+      {
+        pathname: window.location.pathname,
+        search: searchParams.toString(),
+      },
+      { replace: true },
+    );
   };
 
   const handleSubmitOwnerRequest = (newRequest: string, newNoCutlery: boolean) => {
@@ -238,7 +251,7 @@ export default function Payment() {
 
       <PaymentFailModal
         isOpen={isPaymentFailModalOpen}
-        onClose={closePaymentFailModal}
+        onClose={handleCloseFailModal}
         errorMessage={message || '알 수 없는 오류가 발생했습니다.'}
       />
     </div>

--- a/src/util/ts/bridge.ts
+++ b/src/util/ts/bridge.ts
@@ -61,11 +61,11 @@ window.onNativeCallback = (callbackId: string, result: unknown) => {
   window.NativeBridge?.handleCallback(callbackId, result);
 };
 
-function isAndroid() {
+export function isAndroid() {
   return !!window.Android;
 }
 
-function isIOS() {
+export function isIOS() {
   return !!window.webkit?.messageHandlers;
 }
 


### PR DESCRIPTION
## 연관 이슈
- Close #128
  
##  작업 내용 🔍

- issue : #128

## 작업 주요 내용 📝

결제페이지 뒤로가기 분기처리를 추가하여 결제페이지에서는 뒤로가기 시 장바구니 페이지로 이동하도록 고정하였습니다.
결제 실패 모달의 확인 버튼 클릭 시 searchParams의 message를 삭제하여 모달이 지속적으로 렌더링 되는 것을 방지했습니다.
연락처 모달을 닫을 때 reset하는 초기값을 수정했습니다.


## ✔️ PR이 해당 조건들을 만족하는지 확인

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `pnpm lint`
