### PR TITLE
[결제 & 장바구니] 3차 QA 추가 사항

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Cart from './pages/Cart';
 import DeliveryOutside from './pages/Delivery/Outside';
 import OrderCancel from './pages/OrderFinish/OrderCancel';
+import PaymentConfirm from './pages/PaymentConfirm';
 import MenuDetail from './pages/Shop/MenuDetail';
 import OrderableShopView from './pages/Shop/OrderableShopView';
 import OrderableShopDetail from './pages/Shop/ShopDetail/components/OrderableShopDetail';
@@ -24,6 +25,7 @@ export default function App() {
         <Route path="shop/true/:shopId" element={<OrderableShopView />} />
         <Route path="shop/false/:shopId" element={<UnOrderableShopView />} />
         <Route path="shop/true/:shopId/menus/:menuId" element={<MenuDetail />} />
+        <Route path="payment/return" element={<PaymentConfirm />} />
 
         <Route element={<AppLayout />}>
           <Route path="shop-detail/true/:shopId" element={<OrderableShopDetail />} />
@@ -36,7 +38,7 @@ export default function App() {
           </Route>
           <Route path="payment" element={<Payment />} />
           <Route path="orderCancel" element={<OrderCancel />} />
-          <Route path="result" element={<OrderFinish />} />
+          <Route path="result/:paymentId" element={<OrderFinish />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/api/cart/index.ts
+++ b/src/api/cart/index.ts
@@ -12,9 +12,12 @@ export const getCart = async (type: 'DELIVERY' | 'TAKE_OUT') => {
   });
 };
 
-export const validateCart = async () => {
+export const validateCart = async (orderType: 'DELIVERY' | 'TAKE_OUT') => {
   return await apiClient.get<CartResponse>('cart/validate', {
     headers: getAuthHeader(),
+    params: {
+      order_type: orderType,
+    },
   });
 };
 

--- a/src/api/payments/entity.ts
+++ b/src/api/payments/entity.ts
@@ -6,6 +6,7 @@ export interface DeliveryTemporaryRequest {
   total_menu_price: number;
   delivery_tip: number;
   total_amount: number;
+  provide_cutlery: boolean;
 }
 
 export interface TakeoutTemporaryRequest {
@@ -13,6 +14,7 @@ export interface TakeoutTemporaryRequest {
   to_owner: string;
   total_menu_price: number;
   total_amount: number;
+  provide_cutlery: boolean;
 }
 
 export interface TemporaryResponse {

--- a/src/api/payments/entity.ts
+++ b/src/api/payments/entity.ts
@@ -7,7 +7,6 @@ export interface DeliveryTemporaryRequest {
   delivery_tip: number;
   provide_cutlery: boolean;
   total_amount: number;
-  provide_cutlery: boolean;
 }
 
 export interface TakeoutTemporaryRequest {
@@ -16,7 +15,6 @@ export interface TakeoutTemporaryRequest {
   provide_cutlery: boolean;
   total_menu_price: number;
   total_amount: number;
-  provide_cutlery: boolean;
 }
 
 export interface TemporaryResponse {

--- a/src/api/payments/index.ts
+++ b/src/api/payments/index.ts
@@ -26,6 +26,13 @@ export const getTemporaryTakeout = async (body: TakeoutTemporaryRequest) => {
   return response;
 };
 
+export const getPaymentInfo = async (paymentId: number) => {
+  const response = await apiClient.get<ConfirmPaymentsResponse>(`payments/${paymentId}`, {
+    headers: getAuthHeader(),
+  });
+  return response;
+};
+
 export const confirmPayments = async (body: ConfirmPaymentsRequest) => {
   const response = await apiClient.post<ConfirmPaymentsResponse>('payments/confirm', {
     body,

--- a/src/pages/Cart/hooks/useValidateCart.ts
+++ b/src/pages/Cart/hooks/useValidateCart.ts
@@ -21,7 +21,7 @@ export default function useValidateCart({ orderType }: { orderType: 'DELIVERY' |
   const [errorCode, setErrorCode] = useState<string | null>(null);
 
   const mutation = useMutation({
-    mutationFn: validateCart,
+    mutationFn: () => validateCart(orderType),
     onSuccess: () => {
       setErrorCode(null);
       navigate(`/payment?orderType=${orderType}`);

--- a/src/pages/Delivery/Outside/DetailAddress.tsx
+++ b/src/pages/Delivery/Outside/DetailAddress.tsx
@@ -26,7 +26,7 @@ export default function DetailAddress() {
   useMarker(map);
 
   const handleDetailAddress = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setDetailAddressValue(e.target.value.trim());
+    setDetailAddressValue(e.target.value);
   };
 
   const handleClickSaveAddress = () => {

--- a/src/pages/OrderFinish/OrderCancel.tsx
+++ b/src/pages/OrderFinish/OrderCancel.tsx
@@ -111,14 +111,14 @@ export default function OrderCancel() {
       <Modal className="centerModal" isOpen={isCancelModalOpen} onClose={closeCancelModal}>
         <ModalContent>
           <div>주문 취소를 그만두시겠어요?</div>
-          <div className="flex h-12 gap-2 text-[15px]">
+          <div className="flex gap-2 text-[15px]">
             <Button
               onClick={closeCancelModal}
-              className="w-[7.125rem] border border-neutral-400 bg-white font-medium text-neutral-600"
+              className="border border-neutral-400 bg-white py-3 font-medium text-neutral-600"
             >
               그만하기
             </Button>
-            <Button onClick={handleClickMoveMainPage} className="w-[7.125rem] font-medium">
+            <Button onClick={handleClickMoveMainPage} className="py-3 font-medium">
               계속하기
             </Button>
           </div>

--- a/src/pages/OrderFinish/hooks/usePaymentInfo.ts
+++ b/src/pages/OrderFinish/hooks/usePaymentInfo.ts
@@ -1,0 +1,9 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { getPaymentInfo } from '@/api/payments';
+
+export default function usePaymentInfo(paymentId: number) {
+  return useSuspenseQuery({
+    queryKey: ['paymentInfo', paymentId],
+    queryFn: () => getPaymentInfo(paymentId),
+  });
+}

--- a/src/pages/OrderFinish/index.tsx
+++ b/src/pages/OrderFinish/index.tsx
@@ -1,8 +1,8 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
+import clsx from 'clsx';
 import dayjs from 'dayjs';
-import Lottie from 'lottie-react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
-import { ConfirmPaymentsResponse } from '@/api/payments/entity';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import usePaymentInfo from './hooks/usePaymentInfo';
 import CloseIcon from '@/assets/Main/close-icon.svg';
 import CallIcon from '@/assets/OrderFinish/call-icon.svg';
 import Motorcycle from '@/assets/OrderFinish/motorcycle-icon.svg';
@@ -11,84 +11,58 @@ import Receipt from '@/assets/OrderFinish/receipt-icon.svg';
 import ShoppingCart from '@/assets/OrderFinish/shopping-cart-icon.svg';
 import Skillet from '@/assets/OrderFinish/skillet-icon.svg';
 import ArrowGo from '@/assets/Payment/arrow-go-icon.svg';
-import Paying from '@/assets/Payment/paying.json';
 import BottomModal, {
   BottomModalHeader,
   BottomModalContent,
   BottomModalFooter,
 } from '@/components/UI/BottomModal/BottomModal';
 import Button from '@/components/UI/Button';
-import useConfirmPayments from '@/pages/Payment/hooks/useConfirmPayments';
-import { useOrderStore } from '@/stores/useOrderStore';
 import useBooleanState from '@/util/hooks/useBooleanState';
 
+type OrderKind = 'order' | 'preparation' | 'delivery';
+
+const stateTitle = {
+  order: '주문 확인중',
+  preparation: '준비중',
+  delivery: '배달 완료',
+} as const;
+
+const stateMessage = {
+  order: '사장님이 주문을 확인하고 있어요!',
+  preparation: '가게에서 열심히 음식을 조리하고있어요!',
+  delivery: '배달이 완료되었어요 감사합니다!',
+} as const;
+
 export default function OrderFinish() {
-  type OrderKind = 'order' | 'preparation' | 'delivery';
-
-  const stateTitle = {
-    order: '주문 확인중',
-    preparation: '준비중',
-    delivery: '배달 완료',
-  } as const;
-
-  const stateMessage = {
-    order: '사장님이 주문을 확인하고 있어요!',
-    preparation: '가게에서 열심히 음식을 조리하고있어요!',
-    delivery: '배달이 완료되었어요 감사합니다!',
-  } as const;
-
-  const [searchParams] = useSearchParams();
-  const orderType = searchParams.get('orderType');
-  const entryPoint = searchParams.get('entryPoint');
-  const orderId = searchParams.get('orderId');
-  const paymentKey = searchParams.get('paymentKey');
-  const amount = searchParams.get('amount');
   const navigate = useNavigate();
+  const { paymentId } = useParams();
+  const [searchParams] = useSearchParams();
+  const paymentKey = searchParams.get('paymentKey') || ''; //API 응답값에 추가 요청 예정
 
-  const { mutateAsync: confirmPayments, isPending } = useConfirmPayments(orderType!);
+  const { data: paymentInfo } = usePaymentInfo(Number(paymentId));
 
-  const [orderKind, setOrderKind] = useState<OrderKind>('order');
-  const [paymentResponse, setPaymentResponse] = useState<ConfirmPaymentsResponse>();
-
+  const [orderKind] = useState<OrderKind>('order');
   const [isDeliveryBottomModalOpen, , closeDeliveryBottomModal] = useBooleanState(false);
   const [isCallBottomModalOpen, openCallBottomModal, closeCallBottomModal] = useBooleanState(false);
 
-  const isDelivery = orderType === 'delivery';
+  const isDelivery = paymentInfo.order_type === 'DELIVERY';
 
-  const approvedTime = dayjs(paymentResponse?.approved_at);
+  const approvedTime = dayjs(paymentInfo?.approved_at);
   const deliveryFinishTime = approvedTime.add(1, 'hour').format('A h시 mm분');
-
-  useEffect(() => {
-    const confirmPayment = async () => {
-      const response = await confirmPayments({ order_id: orderId!, payment_key: paymentKey!, amount: Number(amount) });
-      setPaymentResponse(response);
-    };
-
-    if (entryPoint === 'payment') {
-      confirmPayment();
-      useOrderStore.persist.clearStorage();
-    }
-  }, [confirmPayments, orderId, paymentKey]);
-
-  if (isPending) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center">
-        <div className="text-[32px] leading-[160%] font-bold">결제 중</div>
-        <div className="leading-[160%] font-medium">잠시만 기다려주세요!</div>
-        <Lottie animationData={Paying} style={{ width: 390, height: 400 }} />
-      </div>
-    );
-  }
 
   const handleOpenCallBottomModal = () => {
     closeDeliveryBottomModal();
     openCallBottomModal();
-    setOrderKind('order'); //lint 에러 떠서 그냥 추가해놓음
   };
 
   const handleClickOrderCancel = () => {
     navigate(`/orderCancel?paymentKey=${paymentKey}`);
   };
+
+  // TODO: paymentInfo가 없을 경우 처리
+  if (!paymentInfo) {
+    return <div>주문 정보가 없습니다.</div>;
+  }
 
   return (
     <div className="flex flex-col">
@@ -141,33 +115,34 @@ export default function OrderFinish() {
       </div>
       <div className="mt-10 px-6">
         <div className="text-primary-500 mb-5 text-lg font-semibold">{isDelivery ? '배달' : '방문'}정보</div>
-        <div className="shadow-1 flex flex-col gap-3 rounded-2xl border border-white bg-white px-6 py-4 text-sm leading-[160%] font-semibold">
-          <div>
+        <div className="shadow-1 flex flex-col rounded-2xl border border-white bg-white px-6 text-sm leading-[160%] font-semibold">
+          <div className="border-b border-neutral-200 py-4">
             {isDelivery ? '배달' : '가게'}주소
-            <div className="border-b border-neutral-200 pb-3 font-normal text-neutral-500">
-              {isDelivery ? paymentResponse?.delivery_address : paymentResponse?.shop_address}
+            <div className="font-normal text-neutral-500">
+              {isDelivery ? paymentInfo.delivery_address : paymentInfo.shop_address}
             </div>
           </div>
-          <div>
+          <div className={clsx('pt-4', isDelivery && 'border-b border-neutral-200 pb-4')}>
             사장님에게
-            <div className={`${isDelivery && 'border-b border-neutral-200 pb-3'} font-normal text-neutral-500`}>
-              {paymentResponse?.to_owner}
+            <div className={`font-normal text-neutral-500`}>
+              {paymentInfo.provide_cutlery ? '수저 · 포크 받기, ' : '수저 · 포크 안 받기 '}
+              {paymentInfo.to_owner}
             </div>
           </div>
           {isDelivery && (
-            <div>
-              배달기사님에게<div className="font-normal text-neutral-500">{paymentResponse?.to_rider}</div>
+            <div className="py-4">
+              배달기사님에게<div className="font-normal text-neutral-500">{paymentInfo.to_rider}</div>
             </div>
           )}
         </div>
         <div className="text-primary-500 my-5 text-lg font-semibold">주문정보</div>
         <div className="shadow-1 mb-16 flex flex-col gap-3 rounded-2xl border border-white bg-white px-6 py-4 text-sm leading-[160%] font-semibold">
           <div className="align-center flex gap-1 border-b border-neutral-200 pt-1 pb-4 pl-1">
-            <div>{paymentResponse?.shop_name}</div>
+            <div>{paymentInfo.shop_name}</div>
             <ArrowGo />
           </div>
           <div className="border-b border-neutral-200 pb-3 text-[13px] font-normal text-neutral-500">
-            {paymentResponse?.menus.map((menu) => (
+            {paymentInfo.menus.map((menu) => (
               <div className="flex gap-2">
                 <div>{menu.name}</div>
                 <div>{menu.quantity}개</div>
@@ -175,9 +150,9 @@ export default function OrderFinish() {
             ))}
           </div>
           <div className="flex flex-row justify-between pb-2">
-            총 결제 금액 <div>{paymentResponse?.amount.toLocaleString()}원</div>
+            총 결제 금액 <div>{paymentInfo.amount.toLocaleString()}원</div>
           </div>
-          <Button className="h-[2.75rem] w-[14.75rem] gap-3 self-center">
+          <Button className="gap-3 self-center px-16 py-2.5">
             <Receipt />
             상세내역 보기
           </Button>
@@ -193,17 +168,17 @@ export default function OrderFinish() {
           </BottomModalHeader>
           <BottomModalContent>
             <div className="text-neutral-600">음식을 수령하셨다면 완료를 눌러주세요</div>
-            <Button onClick={closeDeliveryBottomModal} className="h-[3.063rem] rounded-xl text-lg">
+            <Button onClick={closeDeliveryBottomModal} className="rounded-xl py-2.5 text-lg">
               완료
             </Button>
             <Button
               onClick={handleOpenCallBottomModal}
-              className="h-[3.063rem] rounded-xl border border-neutral-400 bg-white text-lg text-neutral-600"
+              className="rounded-xl border border-neutral-400 bg-white py-2.5 text-lg text-neutral-600"
             >
               아직 못받았어요
             </Button>
           </BottomModalContent>
-          <BottomModalFooter></BottomModalFooter>
+          <BottomModalFooter />
         </BottomModal>
 
         <BottomModal isOpen={isCallBottomModalOpen} onClose={closeCallBottomModal}>
@@ -216,14 +191,14 @@ export default function OrderFinish() {
           <BottomModalContent>
             <div>빠른 해결을 위해 매장에 전화해 보시겠어요?</div>
             <Button
-              className="h-[3.063rem] gap-3 rounded-xl text-lg"
+              className="gap-2.5 rounded-xl py-2.5 text-lg"
               onClick={() => (window.location.href = `tel:010-1234-5678`)} //테스트용 전화번호, api 연동 시 변경
             >
               <CallIcon />
               전화하기
             </Button>
           </BottomModalContent>
-          <BottomModalFooter></BottomModalFooter>
+          <BottomModalFooter />
         </BottomModal>
       </div>
     </div>

--- a/src/pages/Payment/components/ContactModal.tsx
+++ b/src/pages/Payment/components/ContactModal.tsx
@@ -58,7 +58,9 @@ export default function ContactModal({ isOpen, onClose, currentContact, onSubmit
     setCodeErrorMessage('');
     setPhoneErrorMessage('');
     setTimer(0);
-    isTrueEditing();
+
+    const setEditingState = currentContact ? isFalseEditing : isTrueEditing;
+    setEditingState();
   };
 
   const closeModal = () => {

--- a/src/pages/Payment/hooks/useConfirmPayments.ts
+++ b/src/pages/Payment/hooks/useConfirmPayments.ts
@@ -2,12 +2,23 @@ import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { confirmPayments } from '@/api/payments';
 import { ConfirmPaymentsRequest } from '@/api/payments/entity';
+import { useOrderStore } from '@/stores/useOrderStore';
 
-export default function useConfirmPayments(orderType: string) {
+interface UseConfirmPaymentsProps {
+  orderType: string;
+  paymentKey: string;
+}
+
+export default function useConfirmPayments({ orderType, paymentKey }: UseConfirmPaymentsProps) {
   const navigate = useNavigate();
 
   return useMutation({
     mutationFn: (body: ConfirmPaymentsRequest) => confirmPayments(body),
+    onSuccess: (response) => {
+      useOrderStore.persist.clearStorage();
+      navigate(`/result/${response.id}?paymentKey=${paymentKey}`, { replace: true });
+    },
+
     onError: (error) => {
       const errorMessage = JSON.parse(error.message);
 

--- a/src/pages/Payment/index.tsx
+++ b/src/pages/Payment/index.tsx
@@ -93,7 +93,6 @@ export default function Payment() {
         total_menu_price: cart.items_amount,
         delivery_tip: cart.delivery_fee,
         total_amount: cart.total_amount,
-        provide_cutlery: !isCutleryDeclined,
       });
     } else {
       order = await temporaryTakeout({
@@ -102,7 +101,6 @@ export default function Payment() {
         provide_cutlery: !isCutleryDeclined,
         total_menu_price: cart.items_amount,
         total_amount: cart.total_amount,
-        provide_cutlery: !isCutleryDeclined,
       });
     }
     try {

--- a/src/pages/Payment/index.tsx
+++ b/src/pages/Payment/index.tsx
@@ -107,7 +107,7 @@ export default function Payment() {
       await widgets!.requestPayment({
         orderId: order.order_id,
         orderName: orderName,
-        successUrl: window.location.origin + `/result?orderType=${orderType}&entryPoint=payment`,
+        successUrl: window.location.origin + `/payment/return?orderType=${orderType}&entryPoint=payment`,
         failUrl: window.location.origin + `/payment?orderType=${orderType}`,
       });
     } catch (error) {

--- a/src/pages/Payment/index.tsx
+++ b/src/pages/Payment/index.tsx
@@ -68,7 +68,7 @@ export default function Payment() {
 
   const pay = async () => {
     if (!agreement) {
-      showToast('결제 진행을 위해 약관에 동의해주세요.');
+      showToast('결제 이용 약관에 동의해주세요');
       return;
     }
 

--- a/src/pages/Payment/index.tsx
+++ b/src/pages/Payment/index.tsx
@@ -92,6 +92,7 @@ export default function Payment() {
         total_menu_price: cart.items_amount,
         delivery_tip: cart.delivery_fee,
         total_amount: cart.total_amount,
+        provide_cutlery: !isCutleryDeclined,
       });
     } else {
       order = await temporaryTakeout({
@@ -99,9 +100,9 @@ export default function Payment() {
         to_owner: ownerRequest,
         total_menu_price: cart.items_amount,
         total_amount: cart.total_amount,
+        provide_cutlery: !isCutleryDeclined,
       });
     }
-
     try {
       await widgets!.requestPayment({
         orderId: order.order_id,

--- a/src/pages/Payment/index.tsx
+++ b/src/pages/Payment/index.tsx
@@ -35,6 +35,7 @@ export default function Payment() {
   const [isPaymentFailModalOpen, openPaymentFailModal, closePaymentFailModal] = useBooleanState(false);
 
   const [ready, setReady] = useState(false);
+  const [agreement, setAgreement] = useState(true);
   const [widgets, setWidgets] = useState<TossPaymentsWidgets | null>(null);
   const {
     userPhoneNumber,
@@ -66,6 +67,11 @@ export default function Payment() {
   const address = deliveryType === 'CAMPUS' ? campusAddress?.full_address : outsideAddress?.full_address;
 
   const pay = async () => {
+    if (!agreement) {
+      showToast('결제 진행을 위해 약관에 동의해주세요.');
+      return;
+    }
+
     if (!userPhoneNumber) {
       showToast('연락처를 입력해주세요');
       return;
@@ -206,6 +212,7 @@ export default function Payment() {
             currency: 'KRW',
             value: cart.total_amount,
           }}
+          setAgreement={setAgreement}
         />
         <Agreement />
         <PaymentAmount

--- a/src/pages/Payment/index.tsx
+++ b/src/pages/Payment/index.tsx
@@ -184,18 +184,19 @@ export default function Payment() {
             </div>
           </Button>
         </div>
-
-        <div>
-          <p className="text-primary-500 text-lg font-semibold">배달기사님에게</p>
-          <Button onClick={openRiderRequestModal} color="gray" fullWidth className="mt-2 border-0 py-4 pr-3 pl-6">
-            <div className="flex w-full items-center justify-between">
-              <p className="text-start text-sm font-normal text-neutral-600">
-                {!!deliveryRequest ? deliveryRequest : '요청사항 없음'}
-              </p>
-              <RightArrow />
-            </div>
-          </Button>
-        </div>
+        {isDelivery && (
+          <div>
+            <p className="text-primary-500 text-lg font-semibold">배달기사님에게</p>
+            <Button onClick={openRiderRequestModal} color="gray" fullWidth className="mt-2 border-0 py-4 pr-3 pl-6">
+              <div className="flex w-full items-center justify-between">
+                <p className="text-start text-sm font-normal text-neutral-600">
+                  {!!deliveryRequest ? deliveryRequest : '요청사항 없음'}
+                </p>
+                <RightArrow />
+              </div>
+            </Button>
+          </div>
+        )}
 
         <TossWidget
           widgets={widgets}

--- a/src/pages/PaymentConfirm/index.tsx
+++ b/src/pages/PaymentConfirm/index.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+import Lottie from 'lottie-react';
+import { useSearchParams } from 'react-router-dom';
+import useConfirmPayments from '../Payment/hooks/useConfirmPayments';
+import Paying from '@/assets/Payment/paying.json';
+
+export default function PaymentConfirm() {
+  const [searchParams] = useSearchParams();
+  const orderType = searchParams.get('orderType');
+  const orderId = searchParams.get('orderId');
+  const paymentKey = searchParams.get('paymentKey');
+  const amount = searchParams.get('amount');
+
+  const { mutateAsync: confirmPayments, isPending } = useConfirmPayments({
+    orderType: orderType!,
+    paymentKey: paymentKey!,
+  });
+
+  useEffect(() => {
+    const ready = orderId && paymentKey && amount;
+    if (!ready) return;
+
+    confirmPayments({
+      order_id: orderId!,
+      payment_key: paymentKey!,
+      amount: Number(amount),
+    });
+  }, [orderId, paymentKey, amount, confirmPayments]);
+
+  if (isPending) {
+    return (
+      <div className="flex h-screen flex-col items-center justify-center">
+        <div className="text-[32px] leading-[160%] font-bold">결제 중</div>
+        <div className="leading-[160%] font-medium">잠시만 기다려주세요!</div>
+        <Lottie animationData={Paying} style={{ width: 390, height: 400 }} />
+      </div>
+    );
+  }
+
+  return null;
+}


### PR DESCRIPTION
## 연관 이슈
- Close #130
  
##  작업 내용 🔍
- 연락처 검증 로직 변경
- 장바구니 검증 API 변경
- 주문 취소 모달 버튼 크기 조절
- 결제 약관 미동의 토스트 추가
- 포장 주문 시 배달기사 요청사항 숨기기
- 외부주소 상세 페이지 띄어쓰기 불가능한 문제 수정
- 결제 정보 조회 API 추가 및 주문 완료 페이지에 적용
- 주문 완료 페이지 고정된 크기 변경
- 주문 완료 페이지 수저 수령 여부 렌더링 추가

- issue : #130

## 작업 주요 내용 📝

https://www.notion.so/24a9ae650b5980ba92e6ffda444e0b52?source=copy_link

기존 주문 완료 페이지는 POST 요청(confirmPayment) 응답값을 바로 렌더링하는 구조였기 때문에, 새로고침이나 refetch 시 결제 정보를 다시 가져올 수 없는 문제가 있었습니다. 이를 해결하기 위해 결제 정보 조회 API가 추가되었으며, 조회 시 필요한 id 값을 얻기 위해 confirmPayment 응답에서 반환되는 id를 활용하도록 변경했습니다.

또한, 기존에 pending 상태에서 Lottie 애니메이션을 보여주던 부분을 별도의 라우트로 분리하고, confirmPayment 실행 후 결과에 따라 해당 라우트에서 navigate하도록 구현했습니다. orderFinish 페이지 내에서 한 번에 처리하려 했으나, enabled 조건 처리 등으로 로직이 과도하게 복잡해져 별도 페이지로 분리하게 되었습니다.

더 좋은 방법이 있다면 조언해주시면 감사드립니다.

현재 주문 취소페이지로 이동을 위한 paymentKey가 결제 정보 응답값에 포함되어 있지 않아 임시로 parameter 로 받는 중입니다. 
백엔드 측에 API 추가 요청 후 수정하도록 하겠습니다.


## 스크린샷 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## 리뷰 중점 사항


## ✔️ PR이 해당 조건들을 만족하는지 확인

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `pnpm lint`
