### PR TITLE
[공통] 개발용 로그인 페이지 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@bcsdlab/utils": "^0.0.15",
     "@tanstack/react-query": "^5.74.4",
     "@tosspayments/tosspayments-sdk": "^2.3.4",
     "dayjs": "^1.11.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@bcsdlab/utils':
+        specifier: ^0.0.15
+        version: 0.0.15
       '@tanstack/react-query':
         specifier: ^5.74.4
         version: 5.74.4(react@19.1.0)
@@ -208,6 +211,9 @@ packages:
   '@babel/types@7.27.0':
     resolution: {integrity: sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==}
     engines: {node: '>=6.9.0'}
+
+  '@bcsdlab/utils@0.0.15':
+    resolution: {integrity: sha512-JWJtqsVOMlfHokjCWvPBsA09Zsc2KPqR/z8s/oSzUmuQ3Q9xnKKTkswUffRhb+nv4h5ittCbZxU3QwqkEJFNCg==}
 
   '@esbuild/aix-ppc64@0.25.2':
     resolution: {integrity: sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag==}
@@ -749,6 +755,9 @@ packages:
 
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
+  '@types/josa@3.0.5':
+    resolution: {integrity: sha512-BqvmnnEscpq70IgsfXSRQv+t34hBPxoDGB2+q8cGpXkUwmXZ+IH9K+U3dbD0CnDgTlaY+4KpVp7iu3MRcIJctg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -1519,6 +1528,12 @@ packages:
   jiti@2.4.2:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
+
+  jongseong@0.4.2:
+    resolution: {integrity: sha512-wBNM0B48CgphzeIIGo4vFqrAg4wlxppj7fAMa7kZ2PGgwGzoheWxyiBhz4eIxUtlVPMk9gvUsSxG9pMsTyjfSw==}
+
+  josa@3.0.1:
+    resolution: {integrity: sha512-naRZOzWy/02AbP5p4Tz4lj7wpIJ93+hPk/mne8yHCpT2UZglhh2BF0f/j7SIITqZpb834B0DZ0RjJCrKji3qOQ==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2347,6 +2362,11 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
+  '@bcsdlab/utils@0.0.15':
+    dependencies:
+      '@types/josa': 3.0.5
+      josa: 3.0.1
+
   '@esbuild/aix-ppc64@0.25.2':
     optional: true
 
@@ -2748,6 +2768,8 @@ snapshots:
   '@types/estree@1.0.7': {}
 
   '@types/geojson@7946.0.16': {}
+
+  '@types/josa@3.0.5': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -3722,6 +3744,12 @@ snapshots:
       set-function-name: 2.0.2
 
   jiti@2.4.2: {}
+
+  jongseong@0.4.2: {}
+
+  josa@3.0.1:
+    dependencies:
+      jongseong: 0.4.2
 
   js-tokens@4.0.0: {}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import DevOnlyWrapper from './components/Wrapper/DevOnly';
 import Cart from './pages/Cart';
 import DeliveryOutside from './pages/Delivery/Outside';
 import Login from './pages/Login';
@@ -23,7 +24,14 @@ export default function App() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<Login />} />
+        <Route
+          path="/"
+          element={
+            <DevOnlyWrapper>
+              <Login />
+            </DevOnlyWrapper>
+          }
+        />
         <Route path="shop/true/:shopId" element={<OrderableShopView />} />
         <Route path="shop/false/:shopId" element={<UnOrderableShopView />} />
         <Route path="shop/true/:shopId/menus/:menuId" element={<MenuDetail />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Cart from './pages/Cart';
 import DeliveryOutside from './pages/Delivery/Outside';
+import Login from './pages/Login';
 import OrderCancel from './pages/OrderFinish/OrderCancel';
 import PaymentConfirm from './pages/PaymentConfirm';
 import MenuDetail from './pages/Shop/MenuDetail';
@@ -22,6 +23,7 @@ export default function App() {
   return (
     <BrowserRouter>
       <Routes>
+        <Route path="/" element={<Login />} />
         <Route path="shop/true/:shopId" element={<OrderableShopView />} />
         <Route path="shop/false/:shopId" element={<UnOrderableShopView />} />
         <Route path="shop/true/:shopId/menus/:menuId" element={<MenuDetail />} />

--- a/src/api/auth/entity.ts
+++ b/src/api/auth/entity.ts
@@ -1,3 +1,14 @@
+export interface LoginRequest {
+  login_id: string;
+  login_pw: string;
+}
+
+export interface LoginResponse {
+  token: string;
+  refresh_token: string;
+  user_type: string;
+}
+
 export interface StudentUserResponse {
   id: number;
   login_id: string;

--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -1,6 +1,12 @@
 import { apiClient } from '..';
-import { SmsSendResponse, StudentUserResponse } from './entity';
+import { LoginResponse, SmsSendResponse, StudentUserResponse } from './entity';
 import { getAuthHeader } from '@/util/ts/auth';
+
+export const Login = async (login_id: string, login_pw: string) => {
+  return await apiClient.post<LoginResponse>('v2/users/login', {
+    body: { login_id, login_pw },
+  });
+};
 
 export const getStudentInfo = async () => {
   return await apiClient.get<StudentUserResponse>('user/student/me', {

--- a/src/components/Wrapper/DevOnly.tsx
+++ b/src/components/Wrapper/DevOnly.tsx
@@ -1,0 +1,10 @@
+import { type ReactNode } from 'react';
+
+interface DevOnlyWrapperProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+export default function DevOnlyWrapper({ children, fallback = null }: DevOnlyWrapperProps) {
+  return import.meta.env.DEV ? <>{children}</> : <>{fallback}</>;
+}

--- a/src/pages/Login/components/LoginForm.tsx
+++ b/src/pages/Login/components/LoginForm.tsx
@@ -1,0 +1,43 @@
+import { useState, FormEvent } from 'react';
+import useLogin from '../hooks/useLogin';
+import Button from '@/components/UI/Button';
+
+export default function LoginForm() {
+  const { mutate: login, isPending } = useLogin();
+
+  const [loginId, setLoginId] = useState('');
+  const [loginPw, setLoginPw] = useState('');
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    login({ login_id: loginId, login_pw: loginPw });
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex w-full max-w-sm flex-col gap-4 rounded-xl border border-neutral-300 bg-white p-6 shadow"
+    >
+      <div className="text-center text-xl font-semibold">임시 로그인 페이지</div>
+      <input
+        type="text"
+        placeholder="아이디"
+        value={loginId}
+        onChange={(e) => setLoginId(e.target.value)}
+        className="w-full rounded-lg border border-neutral-400 px-3 py-2 text-sm text-neutral-600 placeholder-neutral-400"
+      />
+
+      <input
+        type="password"
+        placeholder="비밀번호"
+        value={loginPw}
+        onChange={(e) => setLoginPw(e.target.value)}
+        className="w-full rounded-lg border border-neutral-400 px-3 py-2 text-sm text-neutral-600 placeholder-neutral-400"
+      />
+
+      <Button fullWidth disabled={isPending}>
+        {isPending ? '로그인 중...' : '로그인'}
+      </Button>
+    </form>
+  );
+}

--- a/src/pages/Login/hooks/useLogin.ts
+++ b/src/pages/Login/hooks/useLogin.ts
@@ -1,0 +1,30 @@
+// src/features/auth/hooks/useLoginMutation.ts
+import { sha256 } from '@bcsdlab/utils';
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { Login } from '@/api/auth';
+import { LoginRequest } from '@/api/auth/entity';
+import { useToast } from '@/util/hooks/useToast';
+import { setCookie } from '@/util/ts/cookie';
+
+const useLogin = () => {
+  const { showToast } = useToast();
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: async ({ login_id, login_pw }: LoginRequest) => {
+      const hashedPassword = await sha256(login_pw);
+      return Login(login_id, hashedPassword);
+    },
+    onSuccess: (response) => {
+      setCookie('AUTH_TOKEN_KEY', response.token);
+      navigate('/shop/true/1'); //메인화면 구현 시 변경
+    },
+    onError: (error) => {
+      console.error('로그인 실패:', error);
+      showToast('로그인을 실패했습니다.');
+    },
+  });
+};
+
+export default useLogin;

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,0 +1,33 @@
+//해당 페이지는 개발 편의를 위해 구현된 페이지입니다. 추후 프로덕션 배포 시 정리 혹은 논의 후 배포하여 주세요.
+
+import LoginForm from './components/LoginForm';
+import Button from '@/components/UI/Button';
+import { deleteCookie, getCookie } from '@/util/ts/cookie';
+
+export default function Login() {
+  const isLogin = getCookie('AUTH_TOKEN_KEY');
+
+  const handleLogoutButton = () => {
+    deleteCookie('AUTH_TOKEN_KEY');
+    window.location.reload();
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      {isLogin ? (
+        <div className="flex w-full max-w-sm flex-col items-center gap-4 rounded-xl border border-neutral-300 bg-white p-6">
+          <div className="text-neutral-600">이미 로그인되어 있습니다.</div>
+          <Button
+            onClick={handleLogoutButton}
+            fullWidth
+            className="border-0 bg-neutral-600 text-white hover:bg-neutral-400"
+          >
+            로그아웃
+          </Button>
+        </div>
+      ) : (
+        <LoginForm />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## 연관 이슈
- Close #137
  
##  작업 내용 🔍

- 기능 : 개발용 로그인 페이지 구현
- issue : #137

## 작업 주요 내용 📝

기존 직접 쿠키에 액세스 토큰을 넣는 방식의 불편함을 줄이기 위해 개발용 로그인 페이지를 구현했습니다.
로그아웃 버튼을 어떻게 처리할까 하다가 그냥 기본 url로 직접 돌아가서 로그아웃 하는 방법으로 구현했습니다.

실제 배포하여 사용될 부분이 아닌지라 간단하게 구현했습니다

## 스크린샷 📷

https://github.com/user-attachments/assets/93f319c8-4698-4772-909d-a8f0538712b3



## ✔️ PR이 해당 조건들을 만족하는지 확인

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `pnpm lint`
