### PR TITLE
[교외 배달] API의 주소와 상세주소 분리로 인한 수정

### DIFF
--- a/src/api/delivery/entity.ts
+++ b/src/api/delivery/entity.ts
@@ -49,6 +49,7 @@ export interface CampusDeliveryAddress {
   latitude: number;
   longitude: number;
 }
+
 export interface CampusDeliveryAddressResponse {
   count: number;
   addresses: CampusDeliveryAddress[];
@@ -61,8 +62,8 @@ export interface OffCampusDeliveryAddressRequest {
   eup_myeon_dong: string;
   road: string;
   building: string;
+  address: string;
   detail_address: string;
-  full_address: string;
 }
 
 interface RiderRequestMessage {

--- a/src/components/Layout/Header/index.tsx
+++ b/src/components/Layout/Header/index.tsx
@@ -36,7 +36,7 @@ export default function Header() {
 
   return (
     <header
-      className={clsx('fixed top-0 right-0 left-0 z-40 flex items-center justify-center', bgClass, 'px-6', layoutClass)}
+      className={clsx('fixed top-0 right-0 left-0 z-40 flex items-center justify-center px-6', bgClass, layoutClass)}
     >
       {pathname.startsWith('/result') ? (
         <button

--- a/src/components/Layout/Header/routeTitles.ts
+++ b/src/components/Layout/Header/routeTitles.ts
@@ -19,7 +19,7 @@ export const ROUTE_TITLES: RouteTitle[] = [
     title: '가게정보·원산지',
   },
   {
-    match: (pathname) => pathname === '/orderCancel',
+    match: (pathname) => pathname.startsWith('/orderCancel'),
     title: '주문 취소하기',
   },
   {

--- a/src/pages/Delivery/Outside/DetailAddress.tsx
+++ b/src/pages/Delivery/Outside/DetailAddress.tsx
@@ -34,8 +34,8 @@ export default function DetailAddress() {
 
     const updatedOutsideAddress = {
       ...outsideAddress,
+      address: address,
       detail_address: detailAddressValue,
-      full_address: `${address} ${detailAddressValue}`,
     };
 
     setOutsideAddress(updatedOutsideAddress);

--- a/src/pages/Delivery/Outside/index.tsx
+++ b/src/pages/Delivery/Outside/index.tsx
@@ -51,8 +51,8 @@ export default function DeliveryOutside() {
               eup_myeon_dong: address.emd_nm,
               road: address.rn,
               building: address.bd_nm,
+              address: '',
               detail_address: '',
-              full_address: '',
             });
             navigate('/delivery/outside/detail', { state: { roadAddress } });
           },

--- a/src/pages/Payment/components/DeliveryAddressSection.tsx
+++ b/src/pages/Payment/components/DeliveryAddressSection.tsx
@@ -24,8 +24,7 @@ export default function DeliveryAddressSection({ orderableShopId }: DeliveryAddr
   const [modalMessage, setModalMessage] = useState<string>('');
   const { deliveryType, outsideAddress, campusAddress } = useOrderStore();
 
-  const existingAddress =
-    deliveryType === 'CAMPUS' ? !!campusAddress?.full_address : outsideAddress.full_address !== '';
+  const existingAddress = deliveryType === 'CAMPUS' ? !!campusAddress?.full_address : outsideAddress.address !== '';
 
   const handleOutsideClick = () => {
     if (!deliveryInfo?.off_campus_delivery) {
@@ -77,7 +76,7 @@ export default function DeliveryAddressSection({ orderableShopId }: DeliveryAddr
                 {deliveryType === 'CAMPUS' ? (
                   <Badge color="primary" size="lg" className="box-border py-1" label={campusAddress?.short_address} />
                 ) : (
-                  <span className="max-w-3xs text-xs font-normal text-neutral-600">{outsideAddress?.full_address}</span>
+                  <span className="max-w-3xs text-xs font-normal text-neutral-600">{outsideAddress?.address}</span>
                 )}
                 <RightArrow />
               </div>

--- a/src/pages/Payment/index.tsx
+++ b/src/pages/Payment/index.tsx
@@ -64,7 +64,7 @@ export default function Payment() {
   const orderName =
     cart.items.length === 1 ? cart.items[0].name : `${cart.items[0].name} 외 ${cart.items.length - 1}건`;
 
-  const address = deliveryType === 'CAMPUS' ? campusAddress?.full_address : outsideAddress?.full_address;
+  const address = deliveryType === 'CAMPUS' ? campusAddress?.full_address : outsideAddress?.address;
 
   const pay = async () => {
     if (!agreement) {

--- a/src/stores/useOrderStore.ts
+++ b/src/stores/useOrderStore.ts
@@ -8,8 +8,8 @@ export interface OutsideAddress {
   eup_myeon_dong: string;
   road: string;
   building: string;
+  address: string;
   detail_address: string;
-  full_address: string;
 }
 
 export interface CampusAddress {
@@ -53,8 +53,8 @@ export const useOrderStore = create<State & Action>()(
         eup_myeon_dong: '',
         road: '',
         building: '',
+        address: '',
         detail_address: '',
-        full_address: '',
       },
       campusAddress: undefined,
       deliveryRequest: '',


### PR DESCRIPTION
## 연관 이슈
- Close #143
  
##  작업 내용 🔍

- 기능 : API 변경에 따른 수정
- issue : #143

## 작업 주요 내용 📝

교외 배달 주소 추가 시 기본 주소와 상세주소를 분리하도록 API가 수정 및 필드값 변경되어 해당 내용 반영하여 수정하였습니다


## ✔️ PR이 해당 조건들을 만족하는지 확인

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `pnpm lint`
