### PR TITLE
[주소 & 주문완료] 지도 렌더링을 위한 백엔드 API 변경사항 반영 

### DIFF
--- a/src/api/payments/entity.ts
+++ b/src/api/payments/entity.ts
@@ -1,10 +1,13 @@
 export interface DeliveryTemporaryRequest {
   address: string;
   address_detail: string;
+  longitude: number;
+  latitude: number;
   phone_number: string;
   to_owner: string;
   to_rider: string;
   total_menu_price: number;
+  delivery_type: 'CAMPUS' | 'OFF_CAMPUS';
   delivery_tip: number;
   provide_cutlery: boolean;
   total_amount: number;
@@ -35,8 +38,10 @@ export interface ConfirmPaymentsResponse {
   approved_at: string;
   payment_method: string;
   delivery_address: string;
-  delivery_address_detail: string;
+  delivery_address_details: string;
   shop_address: string;
+  longitude: number;
+  latitude: number;
   to_owner: string;
   to_rider: string;
   provide_cutlery: boolean;

--- a/src/pages/Delivery/Outside/DetailAddress.tsx
+++ b/src/pages/Delivery/Outside/DetailAddress.tsx
@@ -36,10 +36,12 @@ export default function DetailAddress() {
       ...outsideAddress,
       address: address,
       detail_address: detailAddressValue,
+      latitude: coords[0],
+      longitude: coords[1],
     };
 
     setOutsideAddress(updatedOutsideAddress);
-    setDeliveryType('OUTSIDE');
+    setDeliveryType('OFF_CAMPUS');
     navigate('/payment?orderType=DELIVERY');
     mutate(updatedOutsideAddress);
   };

--- a/src/pages/Delivery/Outside/index.tsx
+++ b/src/pages/Delivery/Outside/index.tsx
@@ -14,7 +14,7 @@ import { useOrderStore } from '@/stores/useOrderStore';
 import useBooleanState from '@/util/hooks/useBooleanState';
 
 export default function DeliveryOutside() {
-  const { setOutsideAddress } = useOrderStore();
+  const { outsideAddress, setOutsideAddress } = useOrderStore();
 
   const navigate = useNavigate();
   const [searchKeyword, setSearchKeyword] = useState<string>('');
@@ -50,14 +50,13 @@ export default function DeliveryOutside() {
         {
           onSuccess: () => {
             setOutsideAddress({
+              ...outsideAddress,
               zip_number: address.zip_no,
               si_do: address.si_nm,
               si_gun_gu: address.sgg_nm,
               eup_myeon_dong: address.emd_nm,
               road: address.rn,
               building: address.bd_nm,
-              address: '',
-              detail_address: '',
             });
             navigate('/delivery/outside/detail', { state: { roadAddress } });
           },

--- a/src/pages/OrderFinish/components/ReceiptModal.tsx
+++ b/src/pages/OrderFinish/components/ReceiptModal.tsx
@@ -81,7 +81,7 @@ export default function ReceiptModal({ isOpen, onClose, paymentInfo }: ReceiptMo
           <div className="space-y-2 text-left">
             <div className="font-semibold">배달 주소</div>
             <div className="text-sm break-words text-black">
-              {paymentInfo.delivery_address} {paymentInfo.delivery_address_detail}
+              {paymentInfo.delivery_address} {paymentInfo.delivery_address_details}
             </div>
           </div>
         </div>

--- a/src/pages/OrderFinish/index.tsx
+++ b/src/pages/OrderFinish/index.tsx
@@ -20,7 +20,6 @@ import BottomModal, {
 } from '@/components/UI/BottomModal/BottomModal';
 import Button from '@/components/UI/Button';
 import useMarker from '@/pages/Delivery/hooks/useMarker';
-import useNaverGeocode from '@/pages/Delivery/hooks/useNaverGeocode';
 import useNaverMap from '@/pages/Delivery/hooks/useNaverMap';
 import { backButtonTapped } from '@/util/bridge/nativeAction';
 import useBooleanState from '@/util/hooks/useBooleanState';
@@ -54,8 +53,7 @@ export default function OrderFinish() {
 
   const { data: paymentInfo } = usePaymentInfo(Number(paymentId));
 
-  const coords = useNaverGeocode(paymentInfo.delivery_address);
-  const map = useNaverMap(...coords);
+  const map = useNaverMap(paymentInfo.latitude, paymentInfo.longitude);
   useMarker(map);
 
   const [orderKind] = useState<OrderKind>('order');
@@ -157,7 +155,7 @@ export default function OrderFinish() {
         <div className="shadow-1 mb-4 w-full rounded-xl">
           <div id="map" className="h-40 w-full rounded-t-xl border border-neutral-300"></div>
           <div className="flex min-h-[3.5rem] w-full items-center justify-between rounded-b-xl bg-white px-6 py-4 text-[0.813rem] text-neutral-600">
-            {paymentInfo.delivery_address}
+            {paymentInfo.delivery_address} {paymentInfo.delivery_address_details}
             <button onClick={() => handleCopyAddress(paymentInfo.delivery_address)}>
               <CopyIcon />
             </button>
@@ -168,7 +166,9 @@ export default function OrderFinish() {
           <div className="border-b border-neutral-200 py-4">
             {isDelivery ? '배달' : '가게'}주소
             <div className="font-normal text-neutral-500">
-              {isDelivery ? paymentInfo.delivery_address : paymentInfo.shop_address}
+              {isDelivery
+                ? `${paymentInfo.delivery_address} ${paymentInfo.delivery_address_details}`
+                : paymentInfo.shop_address}
             </div>
           </div>
           <div className={clsx('py-4', isDelivery && 'border-b border-neutral-200 pb-4')}>

--- a/src/pages/Payment/components/DeliveryAddressSection.tsx
+++ b/src/pages/Payment/components/DeliveryAddressSection.tsx
@@ -50,9 +50,9 @@ export default function DeliveryAddressSection({ orderableShopId }: DeliveryAddr
         <p className="text-primary-500 text-lg font-semibold">배달주소</p>
         {existingAddress ? (
           (deliveryType === 'CAMPUS' && deliveryInfo?.off_campus_delivery) ||
-          (deliveryType === 'OUTSIDE' && deliveryInfo?.campus_delivery) ? (
+          (deliveryType === 'OFF_CAMPUS' && deliveryInfo?.campus_delivery) ? (
             <Link
-              to={`/delivery/${deliveryType === 'CAMPUS' ? 'OUTSIDE' : 'CAMPUS'}`}
+              to={`/delivery/${deliveryType === 'CAMPUS' ? 'OFF_CAMPUS' : 'CAMPUS'}`}
               className="text-xs text-neutral-500 underline"
             >
               {deliveryType === 'CAMPUS' ? '교외 주소를 원하시나요?' : '교내 주소를 원하시나요?'}
@@ -70,13 +70,15 @@ export default function DeliveryAddressSection({ orderableShopId }: DeliveryAddr
               color="gray"
               fullWidth
               className="border-0 p-0 shadow-none"
-              onClick={() => navigate(`/delivery/${deliveryType === 'CAMPUS' ? 'CAMPUS' : 'OUTSIDE'}`)}
+              onClick={() => navigate(`/delivery/${deliveryType === 'CAMPUS' ? 'CAMPUS' : 'OFF_CAMPUS'}`)}
             >
               <div className="flex w-full items-center justify-between text-left">
                 {deliveryType === 'CAMPUS' ? (
                   <Badge color="primary" size="lg" className="box-border py-1" label={campusAddress?.short_address} />
                 ) : (
-                  <span className="max-w-3xs text-xs font-normal text-neutral-600">{outsideAddress?.address}</span>
+                  <span className="max-w-3xs text-xs font-normal text-neutral-600">
+                    {outsideAddress?.address} {outsideAddress?.detail_address}
+                  </span>
                 )}
                 <RightArrow />
               </div>

--- a/src/pages/Payment/index.tsx
+++ b/src/pages/Payment/index.tsx
@@ -88,11 +88,14 @@ export default function Payment() {
       order = await temporaryDelivery({
         address: address!,
         address_detail: address_detail!,
+        longitude: deliveryType === 'CAMPUS' ? campusAddress!.longitude : outsideAddress!.longitude,
+        latitude: deliveryType === 'CAMPUS' ? campusAddress!.latitude : outsideAddress!.latitude,
         phone_number: userPhoneNumber,
         to_owner: ownerRequest,
         to_rider: deliveryRequest,
         provide_cutlery: !isCutleryDeclined,
         total_menu_price: cart.items_amount,
+        delivery_type: deliveryType,
         delivery_tip: cart.delivery_fee,
         total_amount: cart.total_amount,
       });

--- a/src/stores/useOrderStore.ts
+++ b/src/stores/useOrderStore.ts
@@ -10,6 +10,8 @@ export interface OutsideAddress {
   building: string;
   address: string;
   detail_address: string;
+  longitude: number;
+  latitude: number;
 }
 
 export interface CampusAddress {
@@ -23,7 +25,7 @@ export interface CampusAddress {
 
 interface State {
   orderType: 'DELIVERY' | 'TAKE_OUT';
-  deliveryType: 'CAMPUS' | 'OUTSIDE';
+  deliveryType: 'CAMPUS' | 'OFF_CAMPUS';
   outsideAddress: OutsideAddress;
   campusAddress?: CampusAddress;
   deliveryRequest: string;
@@ -33,7 +35,7 @@ interface State {
 }
 interface Action {
   setOrderType: (type: 'DELIVERY' | 'TAKE_OUT') => void;
-  setDeliveryType: (type: 'CAMPUS' | 'OUTSIDE') => void;
+  setDeliveryType: (type: 'CAMPUS' | 'OFF_CAMPUS') => void;
   setOutsideAddress: (addressData: OutsideAddress) => void;
   setCampusAddress: (address: CampusAddress) => void;
   setDeliveryRequest: (request: string) => void;
@@ -56,6 +58,8 @@ export const useOrderStore = create<State & Action>()(
         building: '',
         address: '',
         detail_address: '',
+        longitude: 0,
+        latitude: 0,
       },
       campusAddress: undefined,
       deliveryRequest: '',


### PR DESCRIPTION
## 연관 이슈
- Close #151 

## 작업 주요 내용 📝

기존 교내 배달 주소의 지도 핀을 표시하기 위해 
1. API 응답값에서 주소 추출 
2. 교내 배달 주소 목록 조회
3. 일치하는 주소 필터링
4. 위경도 추출
플로우가 필요했었는데 이 과정이 너무 복잡하고 불필요하다고 생각되어 API에 위경도 값을 요청, 반환하도록 추가하였습니다.

## ✔️ PR이 해당 조건들을 만족하는지 확인

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `pnpm lint`
