### PR TITLE
[주문 완료 & 공통] 네이버 지도 api 사용에 따른 z-index 수정

### DIFF
--- a/src/components/Layout/Header/index.tsx
+++ b/src/components/Layout/Header/index.tsx
@@ -46,7 +46,7 @@ export default function Header() {
 
   return (
     <header
-      className={clsx('fixed top-0 right-0 left-0 z-40 flex items-center justify-center px-6', bgClass, layoutClass)}
+      className={clsx('fixed top-0 right-0 left-0 z-110 flex items-center justify-center px-6', bgClass, layoutClass)}
     >
       {pathname.startsWith('/result') ? (
         <button

--- a/src/components/UI/BottomModal/BottomModal.tsx
+++ b/src/components/UI/BottomModal/BottomModal.tsx
@@ -29,7 +29,7 @@ export default function BottomModal({ isOpen, onClose, children, className }: Bo
 
   return (
     <Portal>
-      <div ref={backgroundRef} className="fixed inset-0 z-100 flex flex-col justify-end bg-black/70">
+      <div ref={backgroundRef} className="fixed inset-0 z-120 flex flex-col justify-end bg-black/70">
         <dialog
           ref={containerRef}
           className={twMerge('w-full max-w-none rounded-t-4xl bg-white', className)}

--- a/src/components/UI/CenterModal/Modal.tsx
+++ b/src/components/UI/CenterModal/Modal.tsx
@@ -21,7 +21,7 @@ export default function Modal({ isOpen, onClose, children, className }: ModalPro
   return (
     <>
       <Portal>
-        <div className="fixed inset-0 z-100 flex items-center justify-center bg-black/70">
+        <div className="fixed inset-0 z-120 flex items-center justify-center bg-black/70">
           <dialog
             ref={modalRef}
             className={twMerge(


### PR DESCRIPTION
## 연관 이슈
- Close #163 
  
##  작업 내용 🔍

- 기능 : 공통 컴포넌트 헤더와 모달 dim 영역의 z-index 수정
- issue : #163

## 작업 주요 내용 📝
네이버 지도 API의 브랜드 로고 및 축척 표기의 z-index가 100으로 헤더, 혹은 dim 영역의 위에 그려지는 문제가 발생하여
각각 110. 120으로 z-index 수정하였습니다

## ✔️ PR이 해당 조건들을 만족하는지 확인

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `pnpm lint`
