### PR TITLE
[공통] apiClient params 배열 허용

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -6,28 +6,64 @@ if (!BASE_URL) {
   throw new Error('API 경로 환경변수가 설정되지 않았습니다.');
 }
 
-interface FetchOptions extends Omit<RequestInit, 'body'> {
+type QueryAtom = string | number | boolean;
+type QueryParamValue = QueryAtom | QueryAtom[];
+
+interface FetchOptions<P extends object = Record<string, QueryParamValue>> extends Omit<RequestInit, 'body'> {
   headers?: Record<string, string>;
   body?: unknown;
-  params?: Record<string, string | number | boolean>;
+  params?: P;
 }
 
 export const apiClient = {
-  get: <T = unknown>(endPoint: string, options: FetchOptions = {}) =>
-    sendRequest<T>(endPoint, { ...options, method: 'GET' }),
-  post: <T = unknown>(endPoint: string, options: FetchOptions = {}) =>
-    sendRequest<T>(endPoint, { ...options, method: 'POST' }),
-  put: <T = unknown>(endPoint: string, options: FetchOptions = {}) =>
-    sendRequest<T>(endPoint, { ...options, method: 'PUT' }),
-  delete: <T = unknown>(endPoint: string, options: FetchOptions = {}) =>
-    sendRequest<T>(endPoint, { ...options, method: 'DELETE' }),
-  patch: <T = unknown>(endPoint: string, options: FetchOptions = {}) =>
-    sendRequest<T>(endPoint, { ...options, method: 'PATCH' }),
+  get: <T = unknown, P extends object = Record<string, QueryParamValue>>(
+    endPoint: string,
+    options: FetchOptions<P> = {},
+  ) => sendRequest<T, P>(endPoint, { ...options, method: 'GET' }),
+  post: <T = unknown, P extends object = Record<string, QueryParamValue>>(
+    endPoint: string,
+    options: FetchOptions<P> = {},
+  ) => sendRequest<T, P>(endPoint, { ...options, method: 'POST' }),
+  put: <T = unknown, P extends object = Record<string, QueryParamValue>>(
+    endPoint: string,
+    options: FetchOptions<P> = {},
+  ) => sendRequest<T, P>(endPoint, { ...options, method: 'PUT' }),
+  delete: <T = unknown, P extends object = Record<string, QueryParamValue>>(
+    endPoint: string,
+    options: FetchOptions<P> = {},
+  ) => sendRequest<T, P>(endPoint, { ...options, method: 'DELETE' }),
+  patch: <T = unknown, P extends object = Record<string, QueryParamValue>>(
+    endPoint: string,
+    options: FetchOptions<P> = {},
+  ) => sendRequest<T, P>(endPoint, { ...options, method: 'PATCH' }),
 };
 
-async function sendRequest<T = unknown>(
+function joinUrl(baseUrl: string, path: string) {
+  const base = baseUrl.replace(/\/+$/, '');
+  const p = path.replace(/^\/+/, '');
+  return `${base}/${p}`;
+}
+
+function buildQuery(params: Record<string, QueryParamValue>) {
+  const usp = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value == null) continue;
+    if (Array.isArray(value)) {
+      if (value.length === 0) continue;
+      for (const v of value) {
+        if (v == null) continue;
+        usp.append(key, String(v));
+      }
+    } else {
+      usp.append(key, String(value));
+    }
+  }
+  return usp.toString();
+}
+
+async function sendRequest<T = unknown, P extends object = Record<string, QueryParamValue>>(
   endPoint: string,
-  options: FetchOptions = {},
+  options: FetchOptions<P> = {},
   timeout: number = 10000,
 ): Promise<T> {
   const { headers, body, method, params, ...restOptions } = options;
@@ -38,26 +74,14 @@ async function sendRequest<T = unknown>(
 
   const token = getCookie('AUTH_TOKEN_KEY');
 
-  // GET 요청의 경우 body 대신 params를 사용하여 URL에 쿼리 문자열 추가
-  let url = `${BASE_URL}/${endPoint}`;
-
+  let url = joinUrl(BASE_URL, endPoint);
   if (params && Object.keys(params).length > 0) {
-    const query = new URLSearchParams(
-      Object.entries(params).reduce(
-        (acc, [key, val]) => {
-          acc[key] = String(val);
-          return acc;
-        },
-        {} as Record<string, string>,
-      ),
-    ).toString();
-    url += `?${query}`;
+    const query = buildQuery(params as Record<string, QueryParamValue>);
+    if (query) url += `?${query}`;
   }
 
   const abortController = new AbortController();
-  const timeoutId = setTimeout(() => {
-    abortController.abort();
-  }, timeout);
+  const timeoutId = setTimeout(() => abortController.abort(), timeout);
 
   const isJsonBody = body !== undefined && body !== null && !(body instanceof FormData);
 
@@ -74,7 +98,10 @@ async function sendRequest<T = unknown>(
     };
 
     if (body !== undefined && body !== null && !['GET', 'HEAD'].includes(method)) {
-      fetchOptions.body = typeof body === 'object' ? JSON.stringify(body) : (body as BodyInit);
+      fetchOptions.body =
+        typeof body === 'object' && !(body instanceof Blob) && !(body instanceof FormData)
+          ? JSON.stringify(body)
+          : (body as BodyInit);
     }
 
     const response = await fetch(url, fetchOptions);


### PR DESCRIPTION
## 연관 이슈
- Close #165
  
##  작업 내용 🔍

- 기능 : apiClient의 params에 배열이 불가능해 다중 옵션 filter api 사용 시 문제가 발생해 배열을 추가했습니다
- issue : #165

## 리뷰 중점 사항


## ✔️ PR이 해당 조건들을 만족하는지 확인

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `pnpm lint`
