### PR TITLE
[QA] 주문내역 스프린트 QA 이슈 수정

### DIFF
--- a/src/components/Layout/Header/index.tsx
+++ b/src/components/Layout/Header/index.tsx
@@ -42,7 +42,7 @@ export default function Header() {
     'bg-[#f8f8fa]': true,
   });
 
-  const layoutClass = pathname.startsWith('/result') ? 'h-15 shadow-4' : 'py-4';
+  const layoutClass = pathname.startsWith('/result') ? 'h-15 shadow-2' : 'py-4';
 
   return (
     <header

--- a/src/pages/OrderFinish/components/OrderMap.tsx
+++ b/src/pages/OrderFinish/components/OrderMap.tsx
@@ -63,7 +63,7 @@ export default function OrderMap({ paymentInfo }: OrderMapProps) {
       map.fitBounds(bounds, { top: 10, right: 10, bottom: 10, left: 10 });
     } else {
       map.setCenter(new naver.maps.LatLng(shopLatitude, shopLongitude));
-      map.setZoom(20);
+      map.setZoom(16);
     }
   }, [map, isDelivery, paymentInfo.latitude, paymentInfo.longitude, shopLatitude, shopLongitude]);
 

--- a/src/pages/OrderFinish/components/ReceiptModal.tsx
+++ b/src/pages/OrderFinish/components/ReceiptModal.tsx
@@ -77,13 +77,17 @@ export default function ReceiptModal({ isOpen, onClose, paymentInfo }: ReceiptMo
               <div>{paymentInfo.easy_pay_company}</div>
             </div>
           </div>
-          <div className="h-[1px] border-b border-neutral-200" />
-          <div className="space-y-2 text-left">
-            <div className="font-semibold">배달 주소</div>
-            <div className="text-sm break-words text-black">
-              {paymentInfo.delivery_address} {paymentInfo.delivery_address_details}
-            </div>
-          </div>
+          {paymentInfo.order_type === 'DELIVERY' && (
+            <>
+              <div className="h-[1px] border-b border-neutral-200" />
+              <div className="space-y-2 text-left">
+                <div className="font-semibold">배달 주소</div>
+                <div className="text-sm break-words text-black">
+                  {paymentInfo.delivery_address} {paymentInfo.delivery_address_details}
+                </div>
+              </div>
+            </>
+          )}
         </div>
       </ModalContent>
     </Modal>

--- a/src/pages/OrderFinish/index.tsx
+++ b/src/pages/OrderFinish/index.tsx
@@ -230,7 +230,10 @@ export default function OrderFinish() {
         </div>
         <div className="text-primary-500 my-5 text-lg font-semibold">주문정보</div>
         <div className="shadow-1 mb-16 flex flex-col gap-4 rounded-2xl bg-white px-6 py-4">
-          <button className="flex gap-1.5 text-sm leading-[160%] font-semibold" onClick={handleGoToShopDetail()}>
+          <button
+            className="flex items-center gap-1.5 text-sm leading-[160%] font-semibold"
+            onClick={handleGoToShopDetail()}
+          >
             <div>{paymentInfo.shop_name}</div>
             <ArrowGo />
           </button>

--- a/src/pages/Shop/MenuDetail/index.tsx
+++ b/src/pages/Shop/MenuDetail/index.tsx
@@ -56,6 +56,7 @@ export default function MenuDetail() {
 
   const AUTH_FAIL = ''; //이 케이스는 올바르지 않은 인증정보일 떄 발생합니다. 백엔드 작업이 끝난 후에 다시 작업해야함.
   const totalQuantity = cartInfo.items.reduce((sum, item) => sum + item.quantity, 0);
+
   const {
     priceId,
     count,
@@ -78,14 +79,14 @@ export default function MenuDetail() {
   const hasImage = imagesForCarousel.length > 0;
 
   const handleAddToCart = () => {
-    if (isEdit && 'orderable_shop_menu_price_id' in updateCartItemOptionsRequest) {
+    if (isEdit && updateCartItemOptionsRequest) {
       updateCartItemOptions(updateCartItemOptionsRequest, {
         onSuccess: () => {
           showToast('메뉴 옵션이 변경되었습니다.');
           navigate(-1);
         },
       });
-    } else if ('menuInfo' in addToCartRequest) {
+    } else if (addToCartRequest) {
       addToCart(addToCartRequest, {
         onSuccess: () => {
           showToast('장바구니에 담았습니다');
@@ -101,7 +102,7 @@ export default function MenuDetail() {
               setNoticeMessage(parsed.message);
               openNoticeModal();
               break;
-            case AUTH_FAIL: //이 케이스는 올바르지 않은 인증정보일 떄 발생합니다.
+            case AUTH_FAIL:
               openLoginRequiredModal();
               break;
             default:
@@ -121,11 +122,11 @@ export default function MenuDetail() {
       <MenuDescription
         name={info.name}
         description={info.description}
-        price={info.prices[0].price}
+        price={info.prices[0]?.price ?? 0}
         noImage={!hasImage}
       />
       <div className="mb-40 px-6">
-        {menuInfo.prices.length > 1 && (
+        {info.prices.length > 1 && (
           <MenuPriceSelects prices={info.prices} selectedPriceId={priceId} selectPrice={selectPrice} />
         )}
         <MenuOptions optionGroups={info.option_groups} selectedOptions={selectedOptions} selectOption={selectOption} />
@@ -134,15 +135,17 @@ export default function MenuDetail() {
       <AddToCartBottomModal
         price={totalPrice}
         isActive={isAllRequiredOptionsSelected}
-        onAddToCart={() => handleAddToCart()}
+        onAddToCart={handleAddToCart}
         isEdit={isEdit}
       />
-      <ResetModal isOpen={isResetModalOpen} onClose={closeResetModal} />
+      {isResetModalOpen && addToCartRequest && (
+        <ResetModal isOpen={isResetModalOpen} onClose={closeResetModal} cartRequest={addToCartRequest} />
+      )}
       <NoticeModal isOpen={isNoticeModalOpen} onClose={closeNoticeModal} message={noticeMessage} />
       <LoginRequiredModal
         isOpen={isLoginRequiredModalOpen}
         onClose={closeLoginRequiredModal}
-        menuOptions={'menuInfo' in addToCartRequest ? addToCartRequest : undefined}
+        menuOptions={addToCartRequest ?? undefined}
       />
     </div>
   );

--- a/src/pages/Shop/components/ResetModal.tsx
+++ b/src/pages/Shop/components/ResetModal.tsx
@@ -1,3 +1,5 @@
+import useAddCart from '../hooks/useAddCart';
+import { AddCartRequest } from '@/api/cart/entity';
 import Button from '@/components/UI/Button';
 import Modal, { ModalContent } from '@/components/UI/CenterModal/Modal';
 import useResetCart from '@/pages/Cart/hooks/useResetCart';
@@ -5,10 +7,18 @@ import useResetCart from '@/pages/Cart/hooks/useResetCart';
 interface ResetModalProps {
   isOpen: boolean;
   onClose: () => void;
+  cartRequest: AddCartRequest;
 }
 
-export default function ResetModal({ isOpen, onClose }: ResetModalProps) {
-  const { mutate: resetCart } = useResetCart();
+export default function ResetModal({ isOpen, onClose, cartRequest }: ResetModalProps) {
+  const { mutateAsync: resetCart } = useResetCart();
+  const { mutateAsync: addToCart } = useAddCart();
+
+  const handleConfirm = async () => {
+    await resetCart();
+    await addToCart(cartRequest);
+    onClose();
+  };
 
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
@@ -28,16 +38,7 @@ export default function ResetModal({ isOpen, onClose }: ResetModalProps) {
           >
             아니오
           </Button>
-          <Button
-            size="lg"
-            color="primary"
-            className="font-medium shadow-none"
-            fullWidth
-            onClick={() => {
-              resetCart();
-              onClose();
-            }}
-          >
+          <Button size="lg" color="primary" className="font-medium shadow-none" fullWidth onClick={handleConfirm}>
             예
           </Button>
         </div>

--- a/src/pages/Shop/components/ShopMenus.tsx
+++ b/src/pages/Shop/components/ShopMenus.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import clsx from 'clsx';
 import { useNavigate } from 'react-router-dom';
 import type { ShopInfoResponse } from '@/api/shop/entity';
 import EmptyThumbnail from '@/assets/Shop/empty_thumbnail.svg';
@@ -77,7 +78,10 @@ export default function ShopMenus({
           <div className="shadow-1 rounded-3xl bg-white">
             {shop.menus.map((menu, idx) => (
               <button
-                className={`flex w-full items-center justify-between py-3 pr-3 pl-4 ${idx !== 0 ? 'border-t border-neutral-300' : ''}`}
+                className={clsx(
+                  'flex w-full items-center justify-between gap-4 py-3 pr-3 pl-4',
+                  idx !== 0 && 'border-t border-neutral-300',
+                )}
                 key={menu.id}
                 name={menu.name}
                 disabled={menu.is_sold_out || !isOrderable}
@@ -86,7 +90,7 @@ export default function ShopMenus({
                 <div className="flex flex-col">
                   <span className="flex h-auto text-start text-lg leading-[1.6] font-semibold">{menu.name}</span>
                   {menu.description && (
-                    <span className="line-clamp-2 text-left text-[12px] leading-[1.6] font-normal text-neutral-500">
+                    <span className="line-clamp-2 text-left text-[12px] leading-[1.6] font-normal break-keep text-neutral-500">
                       {menu.description}
                     </span>
                   )}


### PR DESCRIPTION
## 연관 이슈
- Close #167

## 작업 주요 내용 📝

1. 포장 주문 완료 상세 페이지에서 기본 줌이 20으로 되어 현재 위치 파악에 어려움이 있어 근처 학교, 상점등이 보이도록 줌 값을 수정했습니다.
2. 장바구니에 다른 상점의 상품이 담긴 상태에서 장바구니 담기 시 메뉴가 담기지 않는 문제 수정
3. 메뉴 선택 훅을 useReducer를 사용해 리팩토링 했습니다.
4. 상점 상세페이지의 메뉴 카드의 메뉴 설명과 사진 간의 gap을 추가했습니다.



## 스크린샷 📷

<img width="366" height="412" alt="image" src="https://github.com/user-attachments/assets/b627dc49-182d-4014-bf5a-8090f668ce59" />

<img width="385" height="537" alt="image" src="https://github.com/user-attachments/assets/c44982f4-503e-4d57-8ce2-8797ea7b5992" />


https://github.com/user-attachments/assets/81292736-c603-4226-bea0-1af05250a36c

