### PR TITLE
[주문 완료] 메인 페이지 구현에 따른 navigate 추가

### DIFF
--- a/src/pages/OrderFinish/OrderCancel.tsx
+++ b/src/pages/OrderFinish/OrderCancel.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
 import clsx from 'clsx';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import useCancelPayment from './hooks/useCancelPayment';
 import CheckIcon from '@/assets/OrderFinish/check-icon.svg';
 import Button from '@/components/UI/Button';
 import Modal, { ModalContent } from '@/components/UI/CenterModal/Modal';
+import { isNative } from '@/util/bridge/bridge';
 import { backButtonTapped } from '@/util/bridge/nativeAction';
 import useBooleanState from '@/util/hooks/useBooleanState';
 
@@ -17,6 +18,7 @@ const orderCancelReasons: string[] = [
 ];
 
 export default function OrderCancel() {
+  const navigate = useNavigate();
   const { paymentId } = useParams();
 
   if (!paymentId) {
@@ -47,6 +49,11 @@ export default function OrderCancel() {
 
   const handleClickMoveMainPage = () => {
     cancelPayment({ cancel_reason: selectedCancelReason === '기타' ? customCancelReason : selectedCancelReason });
+    if (isNative()) {
+      backButtonTapped();
+    } else {
+      navigate('/home');
+    }
   };
 
   const handleClickSubmitReason = () => {


### PR DESCRIPTION
## 연관 이슈
- Close #171
  
##  작업 내용 🔍

- 기능 : 브릿지 및 navigate 추가
- issue : #171

## 작업 주요 내용 📝
메인 페이지가 구현됨에 따라 주문 취소시 메인화면으로 이동하는 로직을 추가했습니다

## ✔️ PR이 해당 조건들을 만족하는지 확인

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `pnpm lint`
