### PR TITLE
[주문내역] 무한 스크롤, 준비 중 탭 구현

### DIFF
--- a/src/api/order/entity.ts
+++ b/src/api/order/entity.ts
@@ -27,3 +27,15 @@ export interface OrderParams {
   type: 'NONE' | 'DELIVERY' | 'TAKE_OUT';
   query: string;
 }
+
+export interface InProgressOrder {
+  id: number;
+  payment_id: number;
+  order_type: 'DELIVERY' | 'TAKE_OUT';
+  orderable_shop_name: string;
+  orderable_shop_thumbnail: string;
+  estimated_at: string;
+  order_status: 'CONFIRMING' | 'COOKING' | 'PACKAGED' | 'PICKED_UP' | 'DELIVERING' | 'DELIVERED' | 'CANCELED';
+  order_title: string;
+  total_amount: number;
+}

--- a/src/api/order/index.ts
+++ b/src/api/order/index.ts
@@ -1,10 +1,16 @@
 import { apiClient } from '..';
-import { OrderParams, OrderResponse } from './entity';
+import { InProgressOrder, OrderParams, OrderResponse } from './entity';
 import { getAuthHeader } from '@/util/ts/auth';
 
 export const getOrder = async (params: OrderParams) => {
   return await apiClient.get<OrderResponse, OrderParams>('order', {
     headers: getAuthHeader(),
     params,
+  });
+};
+
+export const getInProgressOrder = async () => {
+  return await apiClient.get<InProgressOrder[]>('order/in-progress', {
+    headers: getAuthHeader(),
   });
 };

--- a/src/pages/OrderList/components/EmptyCard.tsx
+++ b/src/pages/OrderList/components/EmptyCard.tsx
@@ -1,0 +1,23 @@
+import SleepingIcon from '@/assets/OrderHistory/sleeping-icon.svg';
+
+interface EmptyCardProps {
+  activeTab: 'past' | 'preparing';
+  setActiveTab: (tab: 'past' | 'preparing') => void;
+}
+
+export default function EmptyCard({ activeTab, setActiveTab }: EmptyCardProps) {
+  return (
+    <div className="text-primary-500 flex flex-col items-center justify-center gap-4 py-30 text-lg font-semibold">
+      <SleepingIcon />
+      <div>{activeTab === 'preparing' ? '준비 중인 음식이 없어요' : '주문 내역이 없어요'}</div>
+      {activeTab === 'preparing' && (
+        <button
+          className="shadow-1 rounded-lg bg-white p-2 text-sm text-neutral-500"
+          onClick={() => setActiveTab('past')}
+        >
+          과거 주문 내역 보기
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/pages/OrderList/components/OrderCard.tsx
+++ b/src/pages/OrderList/components/OrderCard.tsx
@@ -36,7 +36,10 @@ export default function OrderCard({ orderInfo }: OrderCardProps) {
   const navigate = useNavigate();
 
   return (
-    <div className="rounded-xl border-[0.5px] border-neutral-200 bg-white px-4 py-6">
+    <button
+      className="rounded-xl border-[0.5px] border-neutral-200 bg-white px-4 py-6"
+      onClick={() => navigate(`/shop/true/${orderInfo.orderable_shop_id}`)}
+    >
       <div className="flex justify-between">
         <div className="text-primary-500 flex items-center gap-1">
           <div className="font-semibold">{getOrderStatusText(orderInfo.order_status)}</div>
@@ -68,9 +71,9 @@ export default function OrderCard({ orderInfo }: OrderCardProps) {
           리뷰 쓰기
         </Button>
         <Button color="primary" className="py-3 text-sm" fullWidth disabled={orderInfo.open_status}>
-          같은 메뉴 담기
+          {orderInfo.open_status ? '같은 메뉴 담기' : '같은 메뉴 담기(오픈 전)'}
         </Button>
       </div>
-    </div>
+    </button>
   );
 }

--- a/src/pages/OrderList/components/OrderCardList.tsx
+++ b/src/pages/OrderList/components/OrderCardList.tsx
@@ -1,16 +1,44 @@
+import { useEffect, useRef } from 'react';
 import OrderCard from './OrderCard';
-import { Order } from '@/api/order/entity';
+import type { Order } from '@/api/order/entity';
 
 interface OrderCardListProps {
   orders: Order[];
+  onLoadMore: () => void;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
 }
 
-export default function OrderCardList({ orders }: OrderCardListProps) {
+export default function OrderCardList({ orders, onLoadMore, hasNextPage, isFetchingNextPage }: OrderCardListProps) {
+  const endOfListRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!hasNextPage || !onLoadMore) return;
+
+    const element = endOfListRef.current;
+    if (!element) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const [entry] = entries;
+        if (entry.isIntersecting && !isFetchingNextPage) {
+          onLoadMore();
+        }
+      },
+      { root: null, threshold: 0 },
+    );
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [hasNextPage, onLoadMore, isFetchingNextPage]);
+
   return (
     <div className="mt-4 flex flex-col gap-4 px-6">
       {orders.map((order) => (
         <OrderCard key={order.id} orderInfo={order} />
       ))}
+
+      {hasNextPage && <div ref={endOfListRef} className="h-1 w-full" />}
     </div>
   );
 }

--- a/src/pages/OrderList/components/PreparingCard.tsx
+++ b/src/pages/OrderList/components/PreparingCard.tsx
@@ -1,0 +1,112 @@
+import { useNavigate } from 'react-router-dom';
+import { InProgressOrder } from '@/api/order/entity';
+import PickupIcon from '@/assets/Delivery/bucket.svg';
+import BikeIcon from '@/assets/Main/agriculture.svg';
+import Button from '@/components/UI/Button';
+
+interface PreparingCardProps {
+  orderInfo: InProgressOrder;
+}
+
+const getOrderStatusText = (status: InProgressOrder['order_status']): string | null => {
+  switch (status) {
+    case 'COOKING':
+      return '조리 중';
+    case 'CONFIRMING':
+      return '주문 확인 중';
+    case 'DELIVERING':
+      return '배달 출발';
+    case 'DELIVERED':
+      return '배달 완료';
+    case 'PACKAGED':
+      return '수령 가능';
+    default:
+      return null;
+  }
+};
+
+const getStatusDescription = (status: InProgressOrder['order_status']): string | null => {
+  switch (status) {
+    case 'CONFIRMING':
+      return '사장님이 주문을 확인하고 있어요!';
+    case 'COOKING':
+      return '가게에서 열심히 음식을 조리하고 있어요!';
+    case 'DELIVERING':
+      return '열심히 달려가는 중이에요!';
+    case 'DELIVERED':
+      return '배달이 완료되었어요. 감사합니다!';
+    case 'PACKAGED':
+      return '준비가 완료되었어요!';
+    default:
+      return null;
+  }
+};
+
+export const formatKoreanTime = (hhmm: string): string => {
+  const [hour, minute] = hhmm.split(':');
+  const numHour = Number(hour);
+  const meridiem = numHour < 12 ? '오전' : '오후';
+  const h12 = numHour % 12 || 12;
+  return `${meridiem} ${h12}:${minute}`;
+};
+
+const getEtaText = (order: InProgressOrder): string | null => {
+  if (!order.estimated_at) return null;
+  const time = formatKoreanTime(order.estimated_at);
+
+  if (order.order_type === 'DELIVERY' && (order.order_status === 'COOKING' || order.order_status === 'DELIVERING')) {
+    return `${time} 도착 예정`;
+  }
+
+  if (order.order_type === 'TAKE_OUT' && order.order_status === 'COOKING') {
+    return `${time} 수령 가능`;
+  }
+
+  return null;
+};
+
+export default function PreparingCard({ orderInfo }: PreparingCardProps) {
+  const navigate = useNavigate();
+  const orderStatusText = getOrderStatusText(orderInfo.order_status);
+  const etaText = getEtaText(orderInfo);
+  const statusDescription = getStatusDescription(orderInfo.order_status);
+
+  return (
+    <div className="rounded-xl border-[0.5px] border-neutral-200 bg-white px-6 py-4">
+      <div className="bg-primary-100 inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5">
+        {orderInfo.order_type === 'DELIVERY' ? <BikeIcon /> : <PickupIcon />}
+        <div className="text-primary-500 text-xs font-medium">
+          {orderInfo.order_type === 'DELIVERY' ? '배달' : '포장'}
+        </div>
+      </div>
+      <div className="leading-[160%]">
+        <div className="text-xl font-bold">
+          <div className="text-primary-500 mt-3">{orderStatusText}</div>
+          {etaText && <div className="text-primary-700">{etaText}</div>}
+        </div>
+        <div className="text-xs text-neutral-500">{statusDescription}</div>
+      </div>
+      <div className="my-4 h-[1px] bg-neutral-200" />
+      <div className="flex gap-3">
+        <img
+          src={orderInfo.orderable_shop_thumbnail}
+          alt="상점 메인 썸네일"
+          className="h-22 w-22 rounded-sm border-[0.5px] border-neutral-200 object-cover"
+        />
+        <div className="my-1">
+          <div className="font-semibold">{orderInfo.orderable_shop_name}</div>
+          <div className="my-1.5 text-sm font-medium">{orderInfo.order_title}</div>
+          <div className="text-sm font-semibold">{orderInfo.total_amount.toLocaleString()}원</div>
+        </div>
+      </div>
+      <Button
+        color="neutral"
+        fullWidth
+        className="border-primary-500 mt-4 py-2 text-sm"
+        onClick={() => navigate(`/result/${orderInfo.payment_id}`)}
+      >
+        주문 상세 보기
+      </Button>
+    </div>
+  );
+}

--- a/src/pages/OrderList/components/PreparingCardList.tsx
+++ b/src/pages/OrderList/components/PreparingCardList.tsx
@@ -1,0 +1,16 @@
+import PreparingCard from './PreparingCard';
+import { InProgressOrder } from '@/api/order/entity';
+
+interface PreparingCardListProps {
+  orders: InProgressOrder[];
+}
+
+export default function PreparingCardList({ orders }: PreparingCardListProps) {
+  return (
+    <div className="mt-4 flex flex-col gap-4 px-6">
+      {orders.map((order) => (
+        <PreparingCard key={order.id} orderInfo={order} />
+      ))}
+    </div>
+  );
+}

--- a/src/pages/OrderList/hooks/useInProgressOrder.ts
+++ b/src/pages/OrderList/hooks/useInProgressOrder.ts
@@ -1,0 +1,9 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { getInProgressOrder } from '@/api/order';
+
+export default function useInProgressOrder() {
+  return useSuspenseQuery({
+    queryKey: ['inProgressOrder'],
+    queryFn: () => getInProgressOrder(),
+  });
+}

--- a/src/pages/OrderList/index.tsx
+++ b/src/pages/OrderList/index.tsx
@@ -1,36 +1,62 @@
 import { useState } from 'react';
+import EmptyCard from './components/EmptyCard';
 import OrderCardList from './components/OrderCardList';
 import OrderHistoryTab from './components/OrderHistoryTab';
+import PreparingCardList from './components/PreparingCardList';
+import useInProgressOrder from './hooks/useInProgressOrder';
 import { useOrderHistory } from './hooks/useOrderHistory';
-import SleepingIcon from '@/assets/OrderHistory/sleeping-icon.svg';
-
-function EmptyOrders() {
-  return (
-    <div className="text-primary-500 flex flex-col items-center justify-center gap-4 py-30 text-lg font-semibold">
-      <SleepingIcon />
-      <div>주문 내역이 없어요</div>
-    </div>
-  );
-}
 
 export default function OrderList() {
   const [tab, setTab] = useState<'past' | 'preparing'>('past');
+  const isPast = tab === 'past';
 
-  const { data: orders } = useOrderHistory({
+  const {
+    data: orders = [],
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useOrderHistory({
     page: 1,
     limit: 10,
-    period: 'NONE',
-    status: 'NONE',
-    type: 'NONE',
+    period: 'NONE' as const,
+    status: 'NONE' as const,
+    type: 'NONE' as const,
     query: '',
   });
+  const { data: PreparingOrders } = useInProgressOrder();
 
-  if (!orders) return null;
+  if (isPast && orders.length === 0) {
+    return (
+      <>
+        <OrderHistoryTab activeTab={tab} onTabChange={setTab} />
+        <EmptyCard activeTab="past" setActiveTab={setTab} />
+      </>
+    );
+  }
+
+  if (!isPast && PreparingOrders.length === 0) {
+    return (
+      <>
+        <OrderHistoryTab activeTab={tab} onTabChange={setTab} />
+        <EmptyCard activeTab="preparing" setActiveTab={setTab} />
+      </>
+    );
+  }
 
   return (
     <>
       <OrderHistoryTab activeTab={tab} onTabChange={setTab} />
-      {tab === 'past' && (orders.length === 0 ? <EmptyOrders /> : <OrderCardList orders={orders} />)}
+
+      {isPast ? (
+        <OrderCardList
+          orders={orders}
+          hasNextPage={hasNextPage}
+          isFetchingNextPage={isFetchingNextPage}
+          onLoadMore={() => fetchNextPage()}
+        />
+      ) : (
+        <PreparingCardList orders={PreparingOrders} />
+      )}
     </>
   );
 }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -9,6 +9,7 @@
   --color-primary-200: #DDB1FE;
   --color-primary-300: #ce86fd;
   --color-primary-500: #b611f5;
+  --color-primary-700: #7d08a4;
 
   --color-neutral-300: #e1e1e1;
   --color-neutral-400: #cacaca;


### PR DESCRIPTION
## 연관 이슈
- Close #175
  
##  작업 내용 🔍

- 기능 : 지난 주문 무한스크롤, 준비 중 탭 구현
- issue : #175

## 작업 주요 내용 📝
- 무한스크롤 구현
- 준비 중 탭 UI 구현

## 스크린샷 📷
<img width="391" height="758" alt="image" src="https://github.com/user-attachments/assets/b33f5be3-dcf6-4674-874c-aa4306e70b41" />

https://github.com/user-attachments/assets/40c5ea61-5481-4924-ada4-f1203ad99293


## ✔️ PR이 해당 조건들을 만족하는지 확인

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `pnpm lint`
