### PR TITLE
[결제] 연락처 모달 useEffect 리팩토링

### DIFF
--- a/src/pages/Payment/components/ContactModal.tsx
+++ b/src/pages/Payment/components/ContactModal.tsx
@@ -1,13 +1,13 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import clsx from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import useSendSmsVerification from '../hooks/useSendSmsVerification';
 import CloseIcon from '@/assets/Main/close-icon.svg';
-import Warning from '@/assets/Payment/warning.svg';
+import WarningIcon from '@/assets/Payment/warning.svg';
 import BottomModal, {
-  BottomModalContent,
-  BottomModalFooter,
   BottomModalHeader,
+  BottomModalFooter,
+  BottomModalContent,
 } from '@/components/UI/BottomModal/BottomModal';
 import Button from '@/components/UI/Button';
 import { MESSAGES } from '@/constants/message';
@@ -16,10 +16,9 @@ import useBooleanState from '@/util/hooks/useBooleanState';
 import { useToast } from '@/util/hooks/useToast';
 import formatPhoneNumber from '@/util/ts/formatPhoneNumber';
 
-interface ContactModalProps {
-  isOpen: boolean;
-  onClose: () => void;
+interface ContactFormProps {
   currentContact: string;
+  onClose: () => void;
   onSubmit: (contact: string) => void;
 }
 
@@ -33,34 +32,61 @@ const SMS_CODE_LENGTH = 6;
 const PHONE_NUMBER_LENGTH = 11;
 const CODE_EXPIRE_SECONDS = 180;
 
-export default function ContactModal({ isOpen, onClose, currentContact, onSubmit }: ContactModalProps) {
+function ContactForm({ currentContact, onClose, onSubmit }: ContactFormProps) {
   const { showToast } = useToast();
-
-  const [timer, setTimer] = useState(0);
-  const [phone, setPhone] = useState('');
-  const [authCode, setAuthCode] = useState('');
-  const [codeErrorMessage, setCodeErrorMessage] = useState('');
-  const [phoneErrorMessage, setPhoneErrorMessage] = useState('');
-  const [isEditing, isTrueEditing, isFalseEditing] = useBooleanState(false);
-  const [isCodeSent, isTrueCodeSent, isFalseCodeSent] = useBooleanState(false);
-  const [isPhoneValid, setIsPhoneValid] = useState(false);
 
   const { sendSms, verifySms } = useSendSmsVerification();
   const { mutate: sendSmsVerification } = sendSms;
   const { mutate: verifySmsCode } = verifySms;
 
+  const [timer, setTimer] = useState(0);
+  const [authCode, setAuthCode] = useState('');
+  const [draftPhone, setDraftPhone] = useState('');
+  const [codeErrorMessage, setCodeErrorMessage] = useState('');
+  const [phoneErrorMessage, setPhoneErrorMessage] = useState('');
+  const [isCodeSent, isCodeSentTrue, isCodeSentFalse] = useBooleanState(false);
+  const [isPhoneChanging, startPhoneChanging, stopPhoneChanging] = useBooleanState(false);
+
+  const expiresAtRef = useRef<number | null>(null);
+  const intervalIdRef = useRef<number | null>(null);
+
+  const isEditing = isPhoneChanging || !currentContact;
+  const phone = useMemo(
+    () => (isEditing ? draftPhone : (currentContact ?? '')),
+    [isEditing, draftPhone, currentContact],
+  );
+  const isPhoneValid = phone.length === PHONE_NUMBER_LENGTH;
   const shouldDisableSubmit = !isPhoneValid || authCode.length !== SMS_CODE_LENGTH || timer === 0;
 
+  useEffect(() => {
+    if (intervalIdRef.current != null) return;
+
+    intervalIdRef.current = window.setInterval(() => {
+      if (!expiresAtRef.current) return;
+
+      const remain = Math.max(0, Math.ceil((expiresAtRef.current - Date.now()) / 1000));
+      setTimer(remain);
+
+      if (remain === 0) expiresAtRef.current = null;
+    }, 1000);
+
+    return () => {
+      if (intervalIdRef.current != null) {
+        clearInterval(intervalIdRef.current);
+        intervalIdRef.current = null;
+      }
+    };
+  }, []);
+
   const resetState = () => {
-    setPhone(currentContact);
+    setDraftPhone('');
     setAuthCode('');
-    isFalseCodeSent();
+    isCodeSentFalse();
     setCodeErrorMessage('');
     setPhoneErrorMessage('');
     setTimer(0);
-
-    const setEditingState = currentContact ? isFalseEditing : isTrueEditing;
-    setEditingState();
+    if (currentContact) stopPhoneChanging();
+    else startPhoneChanging();
   };
 
   const closeModal = () => {
@@ -68,32 +94,16 @@ export default function ContactModal({ isOpen, onClose, currentContact, onSubmit
     onClose();
   };
 
-  const handleClickSubmit = () => {
-    verifySmsCode(
-      { phone, code: authCode },
-      {
-        onSuccess: () => {
-          setCodeErrorMessage('');
-          onSubmit(phone);
-          onClose();
-          showToast(MESSAGES.TOAST.VERIFIED);
-          resetState();
-        },
-        onError: (error) => {
-          const errorCode = JSON.parse(error.message);
-          if (errorCode.code === 'NOT_MATCHED_VERIFICATION_CODE') {
-            setCodeErrorMessage(MESSAGES.VERIFICATION.INCORRECT);
-          }
-        },
-      },
-    );
-  };
-
   const handleClickSend = () => {
     setPhoneErrorMessage('');
+    if (!isPhoneValid) {
+      setPhoneErrorMessage(MESSAGES.PHONE.INVALID);
+      return;
+    }
+
     sendSmsVerification(phone, {
       onSuccess: () => {
-        isTrueCodeSent();
+        isCodeSentTrue();
         setTimer(CODE_EXPIRE_SECONDS);
         showToast(MESSAGES.VERIFICATION.CODE_SENT);
       },
@@ -106,143 +116,154 @@ export default function ContactModal({ isOpen, onClose, currentContact, onSubmit
     });
   };
 
-  useEffect(() => {
-    if (currentContact) {
-      setPhone(currentContact);
-      isFalseEditing();
-    } else {
-      setPhone('');
-      isTrueEditing();
-    }
-    isFalseCodeSent();
-    setAuthCode('');
-  }, [currentContact]);
-
-  useEffect(() => {
-    if (!isCodeSent || timer <= 0) return;
-
-    const interval = setInterval(() => {
-      setTimer((prev) => prev - 1);
-    }, 1000);
-
-    return () => clearInterval(interval);
-  }, [isCodeSent, timer]);
-
-  useEffect(() => {
-    setIsPhoneValid(phone.length === PHONE_NUMBER_LENGTH);
-  }, [phone]);
+  const handleClickSubmit = () => {
+    verifySmsCode(
+      { phone, code: authCode },
+      {
+        onSuccess: () => {
+          setCodeErrorMessage('');
+          onSubmit(phone);
+          closeModal();
+          showToast(MESSAGES.TOAST.VERIFIED);
+        },
+        onError: (error) => {
+          const errorCode = JSON.parse(error.message);
+          if (errorCode.code === 'NOT_MATCHED_VERIFICATION_CODE') {
+            setCodeErrorMessage(MESSAGES.VERIFICATION.INCORRECT);
+          }
+        },
+      },
+    );
+  };
 
   return (
-    <BottomModal className="bottomModal" isOpen={isOpen} onClose={closeModal}>
+    <>
+      <div className="relative">
+        <input
+          type="tel"
+          maxLength={13}
+          disabled={!isEditing}
+          value={formatPhoneNumber(phone)}
+          onChange={(e) => {
+            const onlyDigits = e.target.value.replace(/[^0-9]/g, '');
+            setDraftPhone(onlyDigits);
+          }}
+          placeholder="010-1234-5678"
+          className="w-full rounded-xl border border-neutral-300 px-4 py-3 outline-none"
+        />
+        {phoneErrorMessage && (
+          <div className="text-sub-500 mt-1 flex items-center gap-1 text-xs leading-[160%]">
+            <WarningIcon />
+            {phoneErrorMessage}
+          </div>
+        )}
+
+        {currentContact && !isEditing && (
+          <Button
+            color="gray"
+            className="absolute top-2 right-4 px-2.5 text-xs font-normal text-neutral-600 shadow-none"
+            onClick={() => {
+              startPhoneChanging();
+              setDraftPhone('');
+              isCodeSentFalse();
+              setAuthCode('');
+              setTimer(0);
+              setCodeErrorMessage('');
+              setPhoneErrorMessage('');
+            }}
+          >
+            번호 변경
+          </Button>
+        )}
+
+        {isEditing && (
+          <Button
+            color="gray"
+            disabled={!isPhoneValid}
+            className={twMerge(
+              clsx(
+                'absolute top-2 right-4 px-2.5 text-xs font-normal text-neutral-600 shadow-none',
+                !isPhoneValid && 'cursor-not-allowed text-neutral-300',
+              ),
+            )}
+            onClick={handleClickSend}
+          >
+            {isCodeSent ? '인증번호 재발송' : '인증번호 발송'}
+          </Button>
+        )}
+      </div>
+
+      {isCodeSent && (
+        <>
+          <div>
+            <div className="relative">
+              <input
+                type="text"
+                maxLength={6}
+                value={authCode}
+                onChange={(e) => setAuthCode(e.target.value.replace(/[^0-9]/g, ''))}
+                placeholder="6자리를 입력해주세요"
+                className="w-full rounded-xl border border-neutral-300 px-4 py-3 outline-none"
+              />
+              <span className="text-danger-600 absolute top-1/2 right-4 -translate-y-1/2 text-sm">
+                {formatTime(timer)}
+              </span>
+            </div>
+
+            {timer === 0 ? (
+              <div className="text-sub-500 mt-1 flex items-center gap-1 text-xs leading-[160%]">
+                <WarningIcon />
+                {MESSAGES.VERIFICATION.TIMEOUT}
+              </div>
+            ) : codeErrorMessage ? (
+              <div className="text-sub-500 mt-1 flex items-center gap-1 text-xs leading-[160%]">
+                <WarningIcon />
+                {codeErrorMessage}
+              </div>
+            ) : (
+              <div className="mt-1 text-sm leading-[160%] text-neutral-500">
+                {MESSAGES.VERIFICATION.DEFAULT}{' '}
+                <a href={INQUIRE_FORM} className="text-info-500 underline">
+                  문의하기
+                </a>
+              </div>
+            )}
+          </div>
+
+          <Button
+            size="lg"
+            onClick={handleClickSubmit}
+            className="rounded-xl py-2.5 text-lg"
+            disabled={shouldDisableSubmit}
+            state={shouldDisableSubmit ? 'disabled' : 'default'}
+          >
+            확인
+          </Button>
+        </>
+      )}
+    </>
+  );
+}
+
+interface ContactModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  currentContact: string;
+  onSubmit: (contact: string) => void;
+}
+
+export default function ContactModal({ isOpen, onClose, currentContact, onSubmit }: ContactModalProps) {
+  return (
+    <BottomModal className="bottomModal" isOpen={isOpen} onClose={onClose}>
       <BottomModalHeader>
         <div className="flex w-full justify-between">연락처</div>
-        <button type="button" onClick={closeModal}>
+        <button type="button" onClick={onClose}>
           <CloseIcon />
         </button>
       </BottomModalHeader>
-
       <BottomModalContent>
-        <div className="relative">
-          <input
-            type="tel"
-            maxLength={13}
-            disabled={!isEditing}
-            value={formatPhoneNumber(phone)}
-            onChange={(e) => {
-              const onlyDigits = e.target.value.replace(/[^0-9]/g, '');
-              setPhone(onlyDigits);
-            }}
-            placeholder="010-1234-5678"
-            className="w-full rounded-xl border border-neutral-300 px-4 py-3 outline-none"
-          />
-          {phoneErrorMessage && (
-            <div className="text-sub-500 mt-1 flex items-center gap-1 text-xs leading-[160%]">
-              <Warning />
-              {phoneErrorMessage}
-            </div>
-          )}
-
-          {currentContact && !isEditing && (
-            <Button
-              color="gray"
-              className="absolute top-2 right-4 px-2.5 text-xs font-normal text-neutral-600 shadow-none"
-              onClick={() => {
-                setPhone('');
-                isTrueEditing();
-                isFalseCodeSent();
-                setAuthCode('');
-              }}
-            >
-              번호 변경
-            </Button>
-          )}
-
-          {isEditing && (
-            <Button
-              color="gray"
-              disabled={!isPhoneValid}
-              className={twMerge(
-                clsx(
-                  'absolute top-2 right-4 px-2.5 text-xs font-normal text-neutral-600 shadow-none',
-                  !isPhoneValid && 'cursor-not-allowed text-neutral-300',
-                ),
-              )}
-              onClick={handleClickSend}
-            >
-              {isCodeSent ? '인증번호 재발송' : '인증번호 발송'}
-            </Button>
-          )}
-        </div>
-        {isCodeSent && (
-          <>
-            <div>
-              <div className="relative">
-                <input
-                  type="text"
-                  maxLength={6}
-                  value={authCode}
-                  onChange={(e) => setAuthCode(e.target.value.replace(/[^0-9]/g, ''))}
-                  placeholder="6자리를 입력해주세요"
-                  className="w-full rounded-xl border border-neutral-300 px-4 py-3 outline-none"
-                />
-                <span className="text-danger-600 absolute top-1/2 right-4 -translate-y-1/2 text-sm">
-                  {formatTime(timer)}
-                </span>
-              </div>
-
-              {timer === 0 ? (
-                <div className="text-sub-500 mt-1 flex items-center gap-1 text-xs leading-[160%]">
-                  <Warning />
-                  {MESSAGES.VERIFICATION.TIMEOUT}
-                </div>
-              ) : codeErrorMessage ? (
-                <div className="text-sub-500 mt-1 flex items-center gap-1 text-xs leading-[160%]">
-                  <Warning />
-                  {codeErrorMessage}
-                </div>
-              ) : (
-                <div className="mt-1 text-sm leading-[160%] text-neutral-500">
-                  {MESSAGES.VERIFICATION.DEFAULT}{' '}
-                  <a href={INQUIRE_FORM} className="text-info-500 underline">
-                    문의하기
-                  </a>
-                </div>
-              )}
-            </div>
-
-            <Button
-              size="lg"
-              onClick={handleClickSubmit}
-              className="rounded-xl py-2.5 text-lg"
-              disabled={shouldDisableSubmit}
-              state={shouldDisableSubmit ? 'disabled' : 'default'}
-            >
-              확인
-            </Button>
-          </>
-        )}
+        <ContactForm key={currentContact} currentContact={currentContact} onClose={onClose} onSubmit={onSubmit} />
       </BottomModalContent>
-
       <BottomModalFooter />
     </BottomModal>
   );

--- a/src/pages/Payment/components/ContactModal.tsx
+++ b/src/pages/Payment/components/ContactModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import useSendSmsVerification from '../hooks/useSendSmsVerification';
@@ -51,10 +51,8 @@ function ContactForm({ currentContact, onClose, onSubmit }: ContactFormProps) {
   const intervalIdRef = useRef<number | null>(null);
 
   const isEditing = isPhoneChanging || !currentContact;
-  const phone = useMemo(
-    () => (isEditing ? draftPhone : (currentContact ?? '')),
-    [isEditing, draftPhone, currentContact],
-  );
+  const phone = isEditing ? draftPhone : (currentContact ?? '');
+
   const isPhoneValid = phone.length === PHONE_NUMBER_LENGTH;
   const shouldDisableSubmit = !isPhoneValid || authCode.length !== SMS_CODE_LENGTH || timer === 0;
 

--- a/src/pages/Payment/components/ContactModal.tsx
+++ b/src/pages/Payment/components/ContactModal.tsx
@@ -36,8 +36,8 @@ function ContactForm({ currentContact, onClose, onSubmit }: ContactFormProps) {
   const { showToast } = useToast();
 
   const { sendSms, verifySms } = useSendSmsVerification();
-  const { mutate: sendSmsVerification } = sendSms;
-  const { mutate: verifySmsCode } = verifySms;
+  const { mutate: sendSmsVerification, isPending: isSending } = sendSms;
+  const { mutate: verifySmsCode, isPending: isVerifying } = verifySms;
 
   const [timer, setTimer] = useState(0);
   const [authCode, setAuthCode] = useState('');
@@ -177,7 +177,7 @@ function ContactForm({ currentContact, onClose, onSubmit }: ContactFormProps) {
         {isEditing && (
           <Button
             color="gray"
-            disabled={!isPhoneValid}
+            disabled={!isPhoneValid || isSending}
             className={twMerge(
               clsx(
                 'absolute top-2 right-4 px-2.5 text-xs font-normal text-neutral-600 shadow-none',
@@ -232,7 +232,7 @@ function ContactForm({ currentContact, onClose, onSubmit }: ContactFormProps) {
             size="lg"
             onClick={handleClickSubmit}
             className="rounded-xl py-2.5 text-lg"
-            disabled={shouldDisableSubmit}
+            disabled={shouldDisableSubmit || isVerifying}
             state={shouldDisableSubmit ? 'disabled' : 'default'}
           >
             확인

--- a/src/util/hooks/useTimer.ts
+++ b/src/util/hooks/useTimer.ts
@@ -1,0 +1,50 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export default function useTimer() {
+  const [seconds, setSeconds] = useState(0);
+  const expiresAtRef = useRef<number | null>(null);
+  const intervalIdRef = useRef<number | null>(null);
+
+  const clearTick = useCallback(() => {
+    if (intervalIdRef.current != null) {
+      clearInterval(intervalIdRef.current);
+      intervalIdRef.current = null;
+    }
+  }, []);
+
+  const tick = useCallback(() => {
+    if (!expiresAtRef.current) return;
+
+    const remain = Math.max(0, Math.ceil((expiresAtRef.current - Date.now()) / 1000));
+    setSeconds(remain);
+
+    if (remain === 0) {
+      expiresAtRef.current = null;
+      clearTick();
+    }
+  }, [clearTick]);
+
+  const start = useCallback(
+    (durationSeconds: number) => {
+      expiresAtRef.current = Date.now() + durationSeconds * 1000;
+      setSeconds(durationSeconds);
+      if (intervalIdRef.current == null) {
+        intervalIdRef.current = window.setInterval(tick, 1000);
+      }
+      tick();
+    },
+    [tick],
+  );
+
+  const reset = useCallback(() => {
+    expiresAtRef.current = null;
+    setSeconds(0);
+    clearTick();
+  }, [clearTick]);
+
+  useEffect(() => {
+    return () => clearTick();
+  }, [clearTick]);
+
+  return { seconds, start, reset };
+}


### PR DESCRIPTION
## 연관 이슈
- Close #177
  
## 작업 주요 내용 📝
### 1. [props에 따라 state 업데이트](https://ko.react.dev/learn/you-might-not-need-an-effect#updating-state-based-on-props-or-state)
```
// prop → state 동기화 + 모드 전환 + 코드 상태 리셋을 effect에서 수행
useEffect(() => {
    if (currentContact) {
      setPhone(currentContact);
      isFalseEditing();
    } else {
      setPhone('');
      isTrueEditing();
    }
    isFalseCodeSent();
    setAuthCode('');
  }, [currentContact]);
```
#### 잘못된 부분
- phone은 currentContact의 파생값이므로 useEffect로 prop을 state로 설정할 시 불필요한 렌더링, 복잡도 증가 등의 문제가 발생
#### 수정 방안
```
// 렌더링 중에 계산하여 사용
const isEditing = isManualEditing || !currentContact;
const phone = isEditing ? inputPhone : (currentContact ?? '');
```
### 2. [props 변경 시 state 수정](https://ko.react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes)
```
useEffect(() => {
    if (currentContact) {
      setPhone(currentContact);
      isFalseEditing();
    } else {
      setPhone('');
      isTrueEditing();
    }
    isFalseCodeSent();
    setAuthCode('');
  }, [currentContact]);
```
#### 잘못된 부분
- 1번 문제와 유사하게 currentContact가 변경됨에 따라 authCode, isEditing 등의 일부 상태들을 수정함
- props에 종속된 내부상태를 effect로 조정하면 순서, 의존성이 생기고 상태 불일치가 발생하기 쉬움
#### 수정 방안
```
// ContactForm 컴포넌트를 분리 후 key를 기반으로 리마운트 시켜 상태를 초기화
<ContactForm key={currentContact} currentContact={currentContact} onClose={onClose} onSubmit={onSubmit} />
```
### 3. [이벤트 핸들러 간 로직 공유 ](https://ko.react.dev/learn/you-might-not-need-an-effect#sharing-logic-between-event-handlers)
```
useEffect(() => {
    if (!isCodeSent || timer <= 0) return;

    const interval = setInterval(() => {
      setTimer((prev) => prev - 1);
    }, 1000);

    return () => clearInterval(interval);
  }, [isCodeSent, timer]);
```
#### 잘못된 부분
- “인증번호 발송” 후 isCodeSent/timer 변화를 트리거로 useEffect에서 타이머 시작/정지하는 방식으로 구현
- 이벤트 → effect로 우회되며, 원인-결과 연결이 약해져 디버깅이 어려움.
#### 수정 방안
```
// 인증번호 버튼 클릭 시 타이머 시작
setIsCodeSent(true);
expiresAtRef.current = Date.now() + CODE_EXPIRE_SECONDS * 1000;
setTimer(CODE_EXPIRE_SECONDS);
```

```
//useEffect 내부에서는 sideEffect만 관리 타이머는 ref로 확인 후 시작, 종료
useEffect(() => {
    if (intervalIdRef.current != null) return;

    intervalIdRef.current = window.setInterval(() => {
      if (!expiresAtRef.current) return;

      const remain = Math.max(0, Math.ceil((expiresAtRef.current - Date.now()) / 1000));
      setTimer(remain);

      if (remain === 0) expiresAtRef.current = null;
    }, 1000);

    return () => {
      if (intervalIdRef.current != null) {
        clearInterval(intervalIdRef.current);
        intervalIdRef.current = null;
      }
    };
  }, []);
```

## 리뷰 중점 사항
https://ko.react.dev/learn/you-might-not-need-an-effect 해당 문서 읽으면서 문제가 된다고 생각되는 부분들 리팩토링 진행해봤습니다.
3번의 타이머를 ref로 관리하도록 처리한 것이 올바른 코드인지 더 나은 코드가 맞는지 확신이 들지는 않아 많은 의견, 조언 주시면 감사드립니다


## ✔️ PR이 해당 조건들을 만족하는지 확인

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `pnpm lint`
