### PR TITLE
[메인, 주문 완료] API 수정사항 반영

### DIFF
--- a/src/api/order/entity.ts
+++ b/src/api/order/entity.ts
@@ -30,6 +30,7 @@ export interface OrderParams {
 
 export interface InProgressOrder {
   id: number;
+  orderable_shop_id: number;
   payment_id: number;
   order_type: 'DELIVERY' | 'TAKE_OUT';
   orderable_shop_name: string;

--- a/src/api/payments/entity.ts
+++ b/src/api/payments/entity.ts
@@ -34,10 +34,6 @@ export interface ConfirmPaymentsRequest {
 export interface ConfirmPaymentsResponse {
   id: number;
   orderable_shop_id: number;
-  amount: number;
-  requested_at: string;
-  approved_at: string;
-  payment_method: string;
   delivery_address: string;
   delivery_address_details: string;
   shop_address: string;
@@ -46,6 +42,9 @@ export interface ConfirmPaymentsResponse {
   to_owner: string;
   to_rider: string;
   provide_cutlery: boolean;
+  total_menu_price: number;
+  delivery_tip: number;
+  amount: number;
   shop_name: string;
   menus: {
     name: string;
@@ -59,6 +58,11 @@ export interface ConfirmPaymentsResponse {
   }[];
   order_type: 'DELIVERY' | 'TAKE_OUT';
   easy_pay_company: 'string';
+  requested_at: string;
+  approved_at: string;
+  payment_method: string;
+  estimated_at: string;
+  order_status: 'CONFIRMING' | 'COOKING' | 'PACKAGED' | 'PICKED_UP' | 'DELIVERING' | 'DELIVERED' | 'CANCELED';
 }
 
 export interface CancelPaymentRequest {

--- a/src/pages/OrderFinish/components/ReceiptModal.tsx
+++ b/src/pages/OrderFinish/components/ReceiptModal.tsx
@@ -11,11 +11,6 @@ interface ReceiptModalProps {
 const formatKRW = (number: number) => `${number.toLocaleString()}원`;
 
 export default function ReceiptModal({ isOpen, onClose, paymentInfo }: ReceiptModalProps) {
-  const menusSubtotal = paymentInfo.menus.reduce((sum, menu) => {
-    const optionSumPerItem = (menu.options ?? []).reduce((sum, options) => sum + (options.option_price ?? 0), 0);
-    return sum + (menu.price + optionSumPerItem) * menu.quantity;
-  }, 0);
-
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <ModalContent className="px-4 py-6 text-center text-sm text-black">
@@ -54,11 +49,11 @@ export default function ReceiptModal({ isOpen, onClose, paymentInfo }: ReceiptMo
           <div>
             <div className="flex justify-between">
               <div className="font-semibold">주문 금액</div>
-              <div>{formatKRW(menusSubtotal)}</div>
+              <div>{formatKRW(paymentInfo.total_menu_price)}</div>
             </div>
             <div className="flex justify-between">
               <div className="font-semibold">배달비</div>
-              <div>{formatKRW(paymentInfo.amount - menusSubtotal)}</div>
+              <div>{formatKRW(paymentInfo.delivery_tip)}</div>
             </div>
           </div>
           <div className="h-[1px] border-b border-neutral-200" />

--- a/src/pages/OrderList/components/PreparingCard.tsx
+++ b/src/pages/OrderList/components/PreparingCard.tsx
@@ -72,7 +72,18 @@ export default function PreparingCard({ orderInfo }: PreparingCardProps) {
   const statusDescription = getStatusDescription(orderInfo.order_status);
 
   return (
-    <div className="rounded-xl border-[0.5px] border-neutral-200 bg-white px-6 py-4">
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => navigate(`/shop/true/${orderInfo.orderable_shop_id}`)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          navigate(`/shop/true/${orderInfo.orderable_shop_id}`);
+        }
+      }}
+      className="rounded-xl border-[0.5px] border-neutral-200 bg-white px-6 py-4"
+    >
       <div className="bg-primary-100 inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5">
         {orderInfo.order_type === 'DELIVERY' ? <BikeIcon /> : <PickupIcon />}
         <div className="text-primary-500 text-xs font-medium">
@@ -103,7 +114,10 @@ export default function PreparingCard({ orderInfo }: PreparingCardProps) {
         color="neutral"
         fullWidth
         className="border-primary-500 mt-4 py-2 text-sm"
-        onClick={() => navigate(`/result/${orderInfo.payment_id}`)}
+        onClick={(e) => {
+          e.stopPropagation();
+          navigate(`/result/${orderInfo.payment_id}`);
+        }}
       >
         주문 상세 보기
       </Button>


### PR DESCRIPTION
## 연관 이슈
- Close #183
  
##  작업 내용 🔍

- 기능 : api 응답값 추가 및 활용
- issue : #183

## 작업 주요 내용 📝
주문 내역 조회 API 상점 id 응답값 추가
단건 주문 내역 조회의 메뉴 가격, 배달료, 주문 상태 응답값 추가

## 임시 변경 사항
백엔드에서 orderalbe_shop_id를 내려줘야하는데 shop_id를 내려주고 있어서 그냥 orderable_shop-_id로 적용해놓고 백엔드에 수정 요청 드렸습니다

## ✔️ PR이 해당 조건들을 만족하는지 확인

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `pnpm lint`
