### PR TITLE
[테스트] 공통 훅, 공통 컴포넌트 테스트 코드 작성

### DIFF
--- a/tests/CartCountButton.test.tsx
+++ b/tests/CartCountButton.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EMPTY_CART, CART_WITH_ITEMS } from './cartMockData.mock';
+import CartCountButton from '@/components/Layout/Header/components/CartCountButton';
+import useCart from '@/pages/Payment/hooks/useCart';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('@/stores/useOrderStore', () => ({
+  useOrderStore: () => ({ orderType: 'DELIVERY' }),
+}));
+
+vi.mock('@/pages/Payment/hooks/useCart');
+
+vi.mock('@/assets/OrderFinish/shopping-cart-icon.svg', () => ({
+  default: () => <svg data-testid="cart-icon" />,
+}));
+
+describe('CartCountButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('렌더링', () => {
+    it('렌더링이 올바르게 되어야 한다.', () => {
+      vi.mocked(useCart).mockReturnValue({ data: CART_WITH_ITEMS });
+
+      render(<CartCountButton />);
+
+      expect(screen.getByRole('button')).toBeInTheDocument();
+      expect(screen.getByTestId('cart-icon')).toBeInTheDocument();
+    });
+  });
+  describe('조건부 렌더링', () => {
+    it('장바구니가 비어있으면 배지가 표시되지 않아야한다.', () => {
+      vi.mocked(useCart).mockReturnValue({ data: EMPTY_CART });
+
+      render(<CartCountButton />);
+
+      expect(screen.queryByText(/\d/)).not.toBeInTheDocument();
+    });
+    it('장바구니에 상품이 있다면 배지가 올바른 상품 수를 표시해야 한다.', () => {
+      vi.mocked(useCart).mockReturnValue({ data: CART_WITH_ITEMS });
+
+      render(<CartCountButton />);
+
+      const expectedCount = CART_WITH_ITEMS.items.reduce((sum, item) => sum + item.quantity, 0);
+
+      expect(screen.queryByText(expectedCount.toString())).toBeInTheDocument();
+    });
+  });
+  describe('네비게이션', () => {
+    it('버튼을 클릭하면 /cart 페이지로 이동해야 한다', () => {
+      render(<CartCountButton />);
+
+      const button = screen.getByRole('button');
+      fireEvent.click(button);
+
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith('/cart');
+    });
+  });
+});

--- a/tests/CartResetButton.test.tsx
+++ b/tests/CartResetButton.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, vi, expect, beforeEach, it } from 'vitest';
+import { EMPTY_CART, CART_WITH_ITEMS } from './cartMockData.mock';
+import CartResetButton from '@/components/Layout/Header/components/CartResetButton';
+import useCart from '@/pages/Payment/hooks/useCart';
+
+vi.mock('@/stores/useOrderStore', () => ({
+  useOrderStore: () => ({ orderType: 'DELIVERY' }),
+}));
+
+vi.mock('@/pages/Payment/hooks/useCart');
+
+describe('CartResetButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('렌더링', () => {
+    it('버튼이 잘 렌더링되어야 한다', () => {
+      vi.mocked(useCart).mockReturnValue({ data: EMPTY_CART });
+
+      render(<CartResetButton />);
+
+      const button = screen.getByRole('button', { name: '전체삭제' });
+
+      expect(button).toBeInTheDocument();
+    });
+  });
+  describe('버튼 조건부 활성화', () => {
+    it('카트의 상품 개수가 0이면 버튼이 비활성화된다.', () => {
+      vi.mocked(useCart).mockReturnValue({ data: EMPTY_CART });
+
+      render(<CartResetButton />);
+
+      const button = screen.getByRole('button', { name: '전체삭제' });
+
+      expect(button).toBeDisabled();
+    });
+    it('카트에 상품이 있다면 버튼을 활성화된다.', () => {
+      vi.mocked(useCart).mockReturnValue({ data: CART_WITH_ITEMS });
+
+      render(<CartResetButton />);
+
+      const button = screen.getByRole('button', { name: '전체삭제' });
+
+      expect(button).toBeEnabled();
+    });
+  });
+  describe('버튼 클릭', () => {
+    it('버튼 클릭 시 modal이 뜬다', () => {
+      vi.mocked(useCart).mockReturnValue({ data: CART_WITH_ITEMS });
+
+      render(<CartResetButton />);
+
+      const button = screen.getByRole('button', { name: '전체삭제' });
+      fireEvent.click(button);
+
+      expect(screen.getByText('정말로 담았던 메뉴들을')).toBeInTheDocument();
+      expect(screen.getByText('전체 삭제하시겠어요?')).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/cartMockData.mock.ts
+++ b/tests/cartMockData.mock.ts
@@ -1,0 +1,64 @@
+import { CartResponse } from '@/api/cart/entity';
+
+export const CART_WITH_ITEMS: CartResponse = {
+  shop_name: '굿모닝살로만치킨',
+  shop_thumbnail_image_url: 'https://static.koreatech.in/test.png',
+  orderable_shop_id: 2,
+  is_delivery_available: true,
+  is_takeout_available: true,
+  shop_minimum_order_amount: 15000,
+  items: [
+    {
+      cart_menu_item_id: 12,
+      orderable_shop_menu_id: 3,
+      name: '허니콤보',
+      menu_thumbnail_image_url: 'https://static.koreatech.in/test.png',
+      quantity: 1,
+      total_amount: 23000,
+      price: {
+        name: null,
+        price: 23000,
+      },
+      options: [],
+      is_modified: false,
+    },
+    {
+      cart_menu_item_id: 13,
+      orderable_shop_menu_id: 4,
+      name: '레드콤보',
+      menu_thumbnail_image_url: 'https://static.koreatech.in/test.png',
+      quantity: 2,
+      total_amount: 47000,
+      price: {
+        name: '뼈',
+        price: 23000,
+      },
+      options: [
+        {
+          option_group_name: '소스 추가',
+          option_name: '레드디핑 소스',
+          option_price: 500,
+        },
+      ],
+      is_modified: false,
+    },
+  ],
+  items_amount: 70000,
+  delivery_fee: 0,
+  total_amount: 70000,
+  final_payment_amount: 70000,
+};
+
+export const EMPTY_CART: CartResponse = {
+  shop_name: '',
+  shop_thumbnail_image_url: '',
+  orderable_shop_id: 0,
+  is_delivery_available: false,
+  is_takeout_available: false,
+  shop_minimum_order_amount: 0,
+  items: [],
+  total_amount: 0,
+  items_amount: 0,
+  delivery_fee: 0,
+  final_payment_amount: 0,
+};

--- a/tests/useBooleanState.test.tsx
+++ b/tests/useBooleanState.test.tsx
@@ -1,0 +1,74 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import useBooleanState from '@/util/hooks/useBooleanState';
+
+describe('useBooleanState', () => {
+  describe('초기 값이 true일 때 ', () => {
+    it('value는 초기 값과 같다', () => {
+      const { result } = renderHook(() => useBooleanState(true));
+
+      expect(result.current[0]).toBe(true);
+    });
+    it('setTrue는 값을 true로 만든다', () => {
+      const { result } = renderHook(() => useBooleanState(true));
+
+      act(() => {
+        result.current[1]();
+      });
+
+      expect(result.current[0]).toBe(true);
+    });
+    it('setFalse는 값을 false로 만든다.', () => {
+      const { result } = renderHook(() => useBooleanState(true));
+
+      act(() => {
+        result.current[2]();
+      });
+
+      expect(result.current[0]).toBe(false);
+    });
+    it('toggle은 초기값을 반전시다', () => {
+      const { result } = renderHook(() => useBooleanState(true));
+
+      act(() => {
+        result.current[3]();
+      });
+
+      expect(result.current[0]).toBe(false);
+    });
+  });
+  describe('초기값이 false일 때', () => {
+    it('value는 초기값을 가진다', () => {
+      const { result } = renderHook(() => useBooleanState(false));
+
+      expect(result.current[0]).toBe(false);
+    });
+    it('setTrue는 value를 true로 만든다', () => {
+      const { result } = renderHook(() => useBooleanState(false));
+
+      act(() => {
+        result.current[1]();
+      });
+
+      expect(result.current[0]).toBe(true);
+    });
+    it('setFalse는 value를 false로 만든다.', () => {
+      const { result } = renderHook(() => useBooleanState(false));
+
+      act(() => {
+        result.current[2]();
+      });
+
+      expect(result.current[0]).toBe(false);
+    });
+    it('toggle은 초기값을 반전시킨다', () => {
+      const { result } = renderHook(() => useBooleanState(false));
+
+      act(() => {
+        result.current[3]();
+      });
+
+      expect(result.current[0]).toBe(true);
+    });
+  });
+});

--- a/tests/useEscapeKeyDown.test.tsx
+++ b/tests/useEscapeKeyDown.test.tsx
@@ -1,0 +1,38 @@
+import { renderHook, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import useEscapeKeyDown from '@/util/hooks/useEscapeKeyDown';
+
+describe('useEscapeKeyDown', () => {
+  it('Escape 키를 누르면 handler가 호출된다', () => {
+    const handler = vi.fn();
+    renderHook(() => useEscapeKeyDown(handler));
+
+    fireEvent.keyDown(document, { key: 'Escape', code: 'Escape' });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: 'Escape',
+      }),
+    );
+  });
+
+  it('Escape가 아닌 다른 키를 누르면 handler가 호출되지 않는다', () => {
+    const handler = vi.fn();
+    renderHook(() => useEscapeKeyDown(handler));
+
+    fireEvent.keyDown(document, { key: 'Enter', code: 'Enter' });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('unmount 시 이벤트 리스너가 제거된다', () => {
+    const handler = vi.fn();
+    const { unmount } = renderHook(() => useEscapeKeyDown(handler));
+
+    unmount();
+
+    fireEvent.keyDown(document, { key: 'Escape', code: 'Escape' });
+    expect(handler).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 연관 이슈
- Close #195 
  
##  작업 내용 🔍

- 기능 : 공통 훅,컴포넌트에 대한 테스트 코드 추가
- issue : #195

## 작업 주요 내용 📝

공통 훅,컴포넌트에 대한 테스트 코드 추가하였습니다.


## 리뷰 중점 사항
궁금한 점 : CartResetButton에 ResetModal이 있는데 CartResetButton 컴포넌트의 유닛테스트에서 ResetModal의 어느 범위까지 포함시켜야하는지 모르겠습니다.
예를 들면 렌더링 테스트 부분에서 ResetModal도 포함을 해야하는건지에 대한 의문점과 버튼을 눌렀을 때 ResetModal에게 true값을 주는 정도까지만 테스트를 해야하는건지 또는 제가 한 것 처럼 모달이 활성화될때 text를 확인해서 열린것 까지 확인을 해야하는지 등등 어떤 범위가 유닛테스트에서 맞는 범위인지가 궁금합니다.

+테스트 코드가 처음이다보니 아직 잘 모르는 것 같습니다.. 틀린 점 있으면 얘기해주시면 감사하겠습니다.

## ✔️ PR이 해당 조건들을 만족하는지 확인

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `pnpm lint`
