### PR TITLE
[공통] 리뷰어 선정 로직 수정

### DIFF
--- a/.github/workflows/PICK_REVIEWER.yml
+++ b/.github/workflows/PICK_REVIEWER.yml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Pick random reviewer
         id: pick_random_reviewer


### PR DESCRIPTION
## 연관 이슈
- Close #203
  
##  작업 내용 🔍

- 기능 : 리뷰어 선정 로직 수정
- issue : #203

## 작업 주요 내용 📝
### 변경 전
- 기본적으로 actions/checkout은 가상 머지 커밋을 가져오는 로직을 가짐
- 이 가상 머지 커밋은 PR의 base 브랜치와 head 브랜치를 자동으로 병합해 만든 임시 커밋
-  머지가 가능한 상태면 정상적으로 리뷰어 선정 로직이 동작함
- conflict가 있으면 이 merge ref가 아예 만들어지지 않음 → checkout 단계에서 에러 → 워크플로 중단

### 변경 후
- ref: ${{ github.event.pull_request.head.sha }} 로 변경
- PR의 head 커밋만 checkout 하도록 함
- 머지 시도를 아예 하지 않아 충돌이 있어도 checkout이 문제없이 돌아감
- lint나 test 워크플로우는 별도로 동작하기에 문제 없음

## 리뷰 중점 사항
리뷰 올릴 때 conflict 안나도록 확인 후 올리는 것이 올바른 방법이긴 하지만 확인을 못했을 경우 리뷰어가 선정되지 않아 불편함이 발생하여 추가했습니다.

## ✔️ PR이 해당 조건들을 만족하는지 확인

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `pnpm lint`
