### PR TITLE
[공통] 헤더 타이틀 미출력 버그 수정

### DIFF
--- a/src/components/Layout/Header/routeTitles.ts
+++ b/src/components/Layout/Header/routeTitles.ts
@@ -1,5 +1,3 @@
-import { matchPath } from '@/util/ts/matchPath';
-
 export interface RouteTitle {
   match: (pathname: string) => boolean;
   title: string;
@@ -15,7 +13,7 @@ export const ROUTE_TITLES: RouteTitle[] = [
     title: '주문',
   },
   {
-    match: (pathname) => matchPath('/shop-detail/true/:id', pathname) || matchPath('/shop-detail/false/:id', pathname),
+    match: (pathname) => pathname.startsWith('/shop-detail'),
     title: '가게정보·원산지',
   },
   {
@@ -27,7 +25,7 @@ export const ROUTE_TITLES: RouteTitle[] = [
     title: '장바구니',
   },
   {
-    match: (pathname) => pathname === '/shops',
+    match: (pathname) => pathname.startsWith('/shops'),
     title: '주변상점',
   },
   {


### PR DESCRIPTION
## 연관 이슈
- Close #226
  
##  작업 내용 🔍

- 기능 :  버그 수정
- issue : #226

## 작업 주요 내용 📝

기존 path명이 완전히 일치해야만 타이틀이 출력되어 카테고리 선택시 주변상점에서 타이틀이 나오지 않는 문제가 발생하여 startsWith로 수정했습니다.


## ✔️ PR이 해당 조건들을 만족하는지 확인

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `pnpm lint`
